### PR TITLE
Divider and menu bar improvements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -35,25 +35,39 @@ body {
     width: 50%;
     min-width: 200px;
     vertical-align: top;
-    background: #303030;
 }
 
-.menu {
-    cursor: pointer;
-    cursor: hand;
-    color: white;
+.menu-bar {
     font-family: Verdana, Geneva, sans-serif;
     font-size: 12px;
     padding-top: 5px;
     padding-bottom: 5px;
     padding-left: 10px;
+    background: #303030;
+}
+
+.menu-bar h1 {
+    color: white;
+    display: inline-block;
+    font-size: 16px;
     margin: 0;
 }
 
-li.menu {
+.menu-items {
+    display: inline-block;
+    cursor: pointer;
+    cursor: hand;
+    color: white;
+    padding: 0;
+    margin: 0;
+    margin-left: 30px;
+}
+
+.menu-item {
     list-style-type: none;
-    display: inline;
+    display: inline-block;
     text-align: center;
+    margin-right: 20px;
 }
 
 .CodeMirror {

--- a/css/style.css
+++ b/css/style.css
@@ -15,7 +15,9 @@ body {
 /* DRAGABLE LINE */
 
 #divider {
-    position: absolute;
+    position: fixed;
+    left: 0;
+    bottom: 0;
     width: 10px;
     height: 100%;
     vertical-align: top;
@@ -28,10 +30,12 @@ body {
 /* EDITOR */
 
 #content {
-    background: #303030;
     position: absolute;
-    margin-left: 50%;
-    vertical-align : top;
+    right: 0;
+    width: 50%;
+    min-width: 200px;
+    vertical-align: top;
+    background: #303030;
 }
 
 .menu {
@@ -40,9 +44,10 @@ body {
     color: white;
     font-family: Verdana, Geneva, sans-serif;
     font-size: 12px;
-    margin-top: 5px;
-    margin-bottom: 5px;
+    padding-top: 5px;
+    padding-bottom: 5px;
     padding-left: 10px;
+    margin: 0;
 }
 
 li.menu {

--- a/css/style.css
+++ b/css/style.css
@@ -18,11 +18,11 @@ body {
     position: fixed;
     left: 0;
     bottom: 0;
-    width: 10px;
+    width: 6px;
     height: 100%;
     vertical-align: top;
     opacity: 1;
-    background-color: darkgray;
+    background-color: #ccc;
     z-index: 10;
     cursor: col-resize;
 }

--- a/index.html
+++ b/index.html
@@ -66,15 +66,19 @@
 
   <body>
     <div id="wrapper">
+        <div id="menu-container" class="menu-bar">
+            <h1>Tangram-Play</h1>
+            <ul id="menu-holder" class="menu-items">
+                <li class="menu-item" onclick="newContent()"> New </li>
+                <li class="menu-item" onclick="saveContent()"> Save </li>
+                <li class="menu-item"> <select id="examples" onchange="openExample(this)"></select> </li>
+                <li class="menu-item"><input type="file" onchange="openContent(this)"></li>
+            </ul>
+        </div>
+
         <div id="map"></div>
 
         <div id="content">
-            <ul id="menu-holder" class="menu" >
-                <li class="menu" onclick="newContent()"> New </li>
-                <li class="menu" onclick="saveContent()"> Save </li>
-                <li class="menu"> <select id="examples" onchange="openExample(this)"></select> </li>
-                <li class="menu"><input type="file" onchange="openContent(this)"></li>
-            </ul>
             <div id="divider"></div>
             <div id="editor"></div>
         </div>

--- a/index.html
+++ b/index.html
@@ -68,8 +68,6 @@
     <div id="wrapper">
         <div id="map"></div>
 
-        <div id="divider"></div>
-
         <div id="content">
             <ul id="menu-holder" class="menu" >
                 <li class="menu" onclick="newContent()"> New </li>
@@ -77,6 +75,7 @@
                 <li class="menu"> <select id="examples" onchange="openExample(this)"></select> </li>
                 <li class="menu"><input type="file" onchange="openContent(this)"></li>
             </ul>
+            <div id="divider"></div>
             <div id="editor"></div>
         </div>
     </div>

--- a/src/cm-tangram/ui.js
+++ b/src/cm-tangram/ui.js
@@ -65,7 +65,7 @@ function reflowUI() {
     var mapEl = document.getElementById('map');
     var contentEl = document.getElementById('content');
     var dividerEl = document.getElementById('divider');
-    var menuEl = document.getElementById('menu-holder');
+    var menuEl = document.getElementById('menu-container');
     var menuHeight = menuEl.getBoundingClientRect().height;
     var positionX = dividerEl.getBoundingClientRect().left;
 

--- a/src/cm-tangram/ui.js
+++ b/src/cm-tangram/ui.js
@@ -3,7 +3,10 @@ function initUI(cm, tangram) {
 
     Draggable.create("#divider", {
         type: "x",
-        bounds: document.getElementById("wrapper"),
+        bounds: {
+            left: 200,
+            width: window.innerWidth - 200
+        },
         onDrag: reflowUI,
         onDragEnd: function () {
             updateUI(cm, tangram);
@@ -12,7 +15,6 @@ function initUI(cm, tangram) {
 
     loadExamples("data/examples.json");
     window.addEventListener('resize', onWindowResize);
-
     reflowUI();
 };
 
@@ -62,13 +64,15 @@ function reflowUI() {
     var mapEl = document.getElementById('map');
     var contentEl = document.getElementById('content');
     var dividerEl = document.getElementById('divider');
+    var menuEl = document.getElementById('menu-holder');
+    var menuHeight = menuEl.getBoundingClientRect().height;
     var positionX = dividerEl.getBoundingClientRect().left;
 
     mapEl.style.width = positionX + "px";
-    contentEl.style.marginLeft = mapEl.offsetWidth + "px";
     contentEl.style.width = (window.innerWidth - positionX) + "px";
 
-    editor.setSize('100%', (window.innerHeight - 31) + 'px');
+    editor.setSize('100%', (window.innerHeight - menuHeight) + 'px');
+    dividerEl.style.height = (window.innerHeight - menuHeight) + 'px';
 }
 
 function updateUI(editor, map) {

--- a/src/cm-tangram/ui.js
+++ b/src/cm-tangram/ui.js
@@ -7,6 +7,7 @@ function initUI(cm, tangram) {
             left: 200,
             width: window.innerWidth - 200
         },
+        cursor: 'col-resize',
         onDrag: reflowUI,
         onDragEnd: function () {
             updateUI(cm, tangram);


### PR DESCRIPTION
- Editor should always be aligned to right side of window (closes #20).
- Menu bar is full-width of window. (closes #12)
- Tweak divider width and color. Uses col-resize icon.
- Add a 200px min width to map (there is still a bug on the code pane side)
- Add a placeholder title to the page