### PR TITLE
Fix a bug where opening an example will do nothing

### DIFF
--- a/src/cm-tangram/ui.js
+++ b/src/cm-tangram/ui.js
@@ -72,6 +72,10 @@ function initUI(cm, tangram) {
         hideFileDropArea();
     }, true)
     document.getElementById('file-drop').addEventListener('drop', onDropFile, false)
+
+    window.onpopstate = function (e) {
+        loadFromQueryString();
+    }
 };
 
 function setupFileSelector () {
@@ -152,20 +156,34 @@ function loadExamples (configFile) {
 }
 
 function selectExample(event) {
-    var all = document.querySelectorAll('.example-option');
-    for (var i = 0, j = all.length; i < j; i++) {
-        all[i].classList.remove('example-selected');
-    }
     var target = event.target;
     while (!target.classList.contains('example-option')) {
         target = target.parentNode;
     }
+    resetExamples();
     target.classList.add('example-selected');
     document.getElementById('example-confirm').disabled = false;
 }
 
-function openExample(value) {
-    window.location.href = '.?style=' + value + window.location.hash;
+function resetExamples () {
+    var all = document.querySelectorAll('.example-option');
+    for (var i = 0, j = all.length; i < j; i++) {
+        all[i].classList.remove('example-selected');
+    }
+}
+
+function openExample (value) {
+    window.history.pushState(null, null, '.?style=' + value + window.location.hash);
+    loadFromQueryString();
+}
+
+function loadFromQueryString () {
+    /* global querry, editor */
+    querry = parseQuery(window.location.search.slice(1));
+    var source = querry['style'] ? querry['style'] : "data/styles/basic.yaml";
+    var contents = fetchHTTP(source);
+    editor.setValue(contents);
+    editor.isSaved = true;
 }
 
 function onFileSelectorChange (event) {
@@ -325,12 +343,15 @@ function showExamplesModal () {
 
 function hideExamplesModal () {
     hideShield();
+    resetExamples();
+    document.getElementById('example-confirm').disabled = true;
     document.getElementById('choose-example').style.display = 'none';
 }
 
 function onClickOpenExampleFromDialog () {
     var selected = document.querySelectorAll('.example-option.example-selected')[0];
     var value = selected.getAttribute('data-value');
+    hideExamplesModal();
     openExample(value);
 }
 


### PR DESCRIPTION
The bug appears when the example dialog attempts to assign to `window.location.href` the same value as its current value. It does nothing, since the example dialog is relying on the page reload to reset the UI.

We are pretty close to making this very single-page appy, so we might as well keep going. Now instead of relying on page reloads we use history pushState and ask the editor to reload content from the queryString, which updates the map, etc. (much the same was opening and drag/dropping a file does now). So now there is no failure state for attempting to reload the same style (it resets the editor to the original style file, as expected) and the dialog should close itself once a user finishes interaction with it.