### PR TITLE
Remove FileSaver from being loaded in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,6 @@
     <script type="text/javascript" src="src/js/vendor/leaflet-hash.js"></script>     <!-- bog-standard leaflet URL hash -->
     <script type="text/javascript" src="https://mapzen.com/tangram/0.2/tangram.min.js"></script>
 
-    <!-- Save File locally -->
-    <script type="text/javascript" src="src/js/vendor/FileSaver.min.js"></script>
-
     <!-- Color Picker -->
     <script type="text/javascript" src="src/js/vendor/colors.js"></script>
     <script type="text/javascript" src="src/js/addons/widgets/ColorPickerModal.js"></script>

--- a/src/js/core/map.js
+++ b/src/js/core/map.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import LocalStorage from '../addons/LocalStorage.js';
-import { saveAS } from '../vendor/FileSaver.min.js';
+import { saveAs } from '../vendor/FileSaver.min.js';
 
 var take_screenshot = false;
 


### PR DESCRIPTION
FileSaver is an importable module (awesome!) so it plays nicely with Browserify/ES6. It's currently imported in a couple of other modules (map.js, EditorIO.js) and works just fine that way. As a result, we no longer need to load it into global namespace via HTML `<script>` tag. In future, any script that requires FileSaver should be able to import it as needed.