### PR TITLE
Shim color.js for Browserify/ES6 import

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,6 +47,7 @@ gulp.task('css', function () {
 // Build Javascripts
 gulp.task('js', function () {
     var browserify = require('browserify');
+    var shim = require('browserify-shim');
     var babelify = require('babelify');
     var source = require('vinyl-source-stream');
     var buffer = require('vinyl-buffer');
@@ -55,7 +56,7 @@ gulp.task('js', function () {
     var bundle = browserify({
         entries: 'src/js/TangramPlay.js',
         debug: true,
-        transform: [babelify]
+        transform: [babelify, shim]
     });
 
     return bundle.bundle()

--- a/index.html
+++ b/index.html
@@ -19,9 +19,6 @@
     <script type="text/javascript" src="src/js/vendor/leaflet-hash.js"></script>     <!-- bog-standard leaflet URL hash -->
     <script type="text/javascript" src="https://mapzen.com/tangram/0.2/tangram.min.js"></script>
 
-    <!-- Color Picker -->
-    <script type="text/javascript" src="src/js/vendor/colors.js"></script>
-
     <!-- Glsl Sandbox in a canvas -->
     <script type="text/javascript" src="https://rawgit.com/patriciogonzalezvivo/glslCanvas/master/build/GlslCanvas.min.js"></script>
     <!-- Application -->

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "babelify": "^6.1.2",
     "browserify": "^10.2.4",
+    "browserify-shim": "^3.8.10",
     "cssnext": "^1.8.0",
     "gulp": "^3.9.0",
     "gulp-livereload": "^3.8.0",
@@ -39,5 +40,8 @@
     "babel": "^5.6.14",
     "codemirror": "4.12.0",
     "gsap": "^1.17.0"
+  },
+  "browserify-shim": {
+    "./src/js/vendor/colors.js": "Colors"
   }
 }

--- a/src/js/addons/widgets/ColorPickerModal.js
+++ b/src/js/addons/widgets/ColorPickerModal.js
@@ -1,5 +1,6 @@
 'use strict';
-/* global Colors */
+
+import Colors from '../../vendor/colors.js';
 
 // Import Greensock (GSAP)
 import 'gsap/src/uncompressed/Tweenlite.js';


### PR DESCRIPTION
Now it's imported like everything else, instead of having to put it in a script tag in the HTML. To do this I had to use `browserify-shim` which allows libraries that do not normally export behave as if it were. This process could easily be extended to other external dependencies that do not provide an export interface.