### PR TITLE
Escape regex special characters

### DIFF
--- a/src/js/addons/SuggestManager.js
+++ b/src/js/addons/SuggestManager.js
@@ -2,7 +2,7 @@ import TangramPlay from 'app/TangramPlay';
 
 // Load some common functions
 import { httpGet } from 'app/core/common';
-import { getText, getLineInd, isCommented, isEmpty, getValue } from 'app/core/codemirror/tools';
+import { getText, getLineInd, isCommented, isEmpty, getValue, regexEscape } from 'app/core/codemirror/tools';
 import { getAddressSceneContent, getKeyPairs, getAddressForLevel } from 'app/core/codemirror/yaml-tangram';
 
 // Import CodeMirror
@@ -121,7 +121,7 @@ export default class SuggestManager {
                         }
                     }
 
-                    let string = getText(editor, nLine);
+                    let string = regexEscape(getText(editor, nLine));
                     if (string !== '') {
                         let matchedList = [];
                         let match = RegExp('^' + string + '.*');
@@ -144,7 +144,7 @@ export default class SuggestManager {
                             break;
                         }
                     }
-                    let string = keyPair.value;
+                    let string = regexEscape(keyPair.value);
                     if (string !== '') {
                         let matchedList = [];
                         let match = RegExp('^' + string + '.*');

--- a/src/js/core/codemirror/tools.js
+++ b/src/js/core/codemirror/tools.js
@@ -52,6 +52,12 @@ export function getValue(cm, nLine) {
     return value ? value[1] : '';
 }
 
+// Escape regex special characters
+// via http://stackoverflow.com/a/9310752
+export function regexEscape(text) {
+    return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+}
+
 //  Common NAVIGATION functions on CM
 //  ===============================================================================
 


### PR DESCRIPTION
This fixes the infinite loop behavior observed when editing some keys. This was caused by the `[]` characters in YAML sequences being interpreted as regex character classes. I've added an escape utility function that is then called before the `SuggestManager` attempts to find a hint (this is where the problem was). Note that we will need to call this escape function anytime YAML content is used inside a regular expression (when the YAML content *itself* is used as a regex, not just whenever a regex is tested against YAML content). The `SuggestManager` was the only place I could currently find that does this, if there are others they should be updated too.

Note: this does **not** update the build files.