### PR TITLE
Refactor most cases of httpGet() to use Fetch API

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gsap": "^1.18.0",
     "leaflet": "^1.0.0-beta.2",
     "leaflet-hash": "^0.2.1",
+    "whatwg-fetch": "^0.11.0",
     "xhr": "^2.2.0"
   },
   "browserify-shim": {

--- a/src/js/TangramPlay.js
+++ b/src/js/TangramPlay.js
@@ -1,3 +1,6 @@
+// Polyfills
+import 'whatwg-fetch';
+
 // Core elements
 import Map from 'app/core/map';
 import { initEditor } from 'app/core/editor';

--- a/src/js/addons/ui/Modal.Examples.js
+++ b/src/js/addons/ui/Modal.Examples.js
@@ -3,7 +3,6 @@
 import TangramPlay, { container } from 'app/TangramPlay';
 import Modal from 'app/addons/ui/Modal';
 import EditorIO from 'app/addons/ui/EditorIO';
-import { httpGet } from 'app/tools/common';
 
 let examplesEl;
 
@@ -42,32 +41,42 @@ export default class ExamplesModal extends Modal {
 
 // TODO: Refactor
 function loadExamples (configFile) {
-    httpGet(configFile, function (err, res) {
-        const data = JSON.parse(res);
-        const listEl = examplesEl.querySelector('.tp-example-list');
+    window.fetch(configFile)
+        .then((response) => {
+            if (response.status !== 200) {
+                throw response.status;
+            }
 
-        for (let example of data['examples']) {
-            let newOption = document.createElement('div');
-            let nameEl = document.createElement('div');
-            let name = example['name'].split('.')[0];
-            let thumbnailEl = document.createElement('div');
-            newOption.className = 'tp-example-option';
-            newOption.setAttribute('data-value', example['url']);
-            nameEl.className = 'tp-example-option-name';
-            nameEl.textContent = name.replace(/-/g, ' ');
-            thumbnailEl.className = 'tp-example-thumbnail';
-            thumbnailEl.style.backgroundColor = 'rgba(255,255,255,0.05)';
-            thumbnailEl.style.backgroundImage = 'url(' + example['thumb'] + ')';
-            newOption.appendChild(nameEl);
-            newOption.appendChild(thumbnailEl);
-            newOption.addEventListener('click', selectExample);
-            listEl.appendChild(newOption);
-            newOption.addEventListener('dblclick', function (e) {
-                // This is a bit ridiculous
-                TangramPlay.ui.menu.examplesModal._handleConfirm();
+            return response.json();
+        })
+        .then((data) => {
+            const listEl = examplesEl.querySelector('.tp-example-list');
+
+            data.examples.forEach(function (example) {
+                let newOption = document.createElement('div');
+                let nameEl = document.createElement('div');
+                let name = example['name'].split('.')[0];
+                let thumbnailEl = document.createElement('div');
+                newOption.className = 'tp-example-option';
+                newOption.setAttribute('data-value', example['url']);
+                nameEl.className = 'tp-example-option-name';
+                nameEl.textContent = name.replace(/-/g, ' ');
+                thumbnailEl.className = 'tp-example-thumbnail';
+                thumbnailEl.style.backgroundColor = 'rgba(255,255,255,0.05)';
+                thumbnailEl.style.backgroundImage = 'url(' + example['thumb'] + ')';
+                newOption.appendChild(nameEl);
+                newOption.appendChild(thumbnailEl);
+                newOption.addEventListener('click', selectExample);
+                listEl.appendChild(newOption);
+                newOption.addEventListener('dblclick', function (e) {
+                    // This is a bit ridiculous
+                    TangramPlay.ui.menu.examplesModal._handleConfirm();
+                });
             });
-        }
-    });
+        })
+        .catch((error) => {
+            console.error('Error retrieving config file.', error);
+        });
 }
 
 function selectExample (event) {


### PR DESCRIPTION
Fetch API is more future-friendly, and has built in error-catching, which will allow us to either display error messages, log it, fall back, etc etc. Currently errors will be logged to the console, but there is now a way to expand how we deal with errors in the future. Our homegrown httpGet() function is a light abstraction over XMLHttpRequest but has no way to handle errors.

Currently the only remaining instance of httpGet is when we are debouncing requests to the Mapzen Search API. The debounce function we are using does not handle Promises, so the next step is to investigate how to properly debounce functions that return Promises.