### PR TITLE
Update to babel6

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   node:
     version: 4.4.1
   environment:
-    NODE_ENV: production
+    NODE_ENV: deployment
 
 dependencies:
   post:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,12 +55,8 @@ gulp.task('js', function () {
 
     var bundle = browserify({
         entries: 'src/js/TangramPlay.js',
-        debug: true,
-        transform: [
-            babelify.configure({ optional: ['runtime'] }),
-            shim
-        ]
-    });
+        debug: true
+    }).transform('babelify', { presets: ['es2015'] })
 
     // Only uglify in production, because
     // this doubles build time locally!

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,8 +55,12 @@ gulp.task('js', function () {
 
     var bundle = browserify({
         entries: 'src/js/TangramPlay.js',
-        debug: true
-    }).transform('babelify', { presets: ['es2015'] })
+        debug: true,
+        transform: [
+            babelify.configure({ presets: ['es2015'] }),
+            shim
+        ]
+    });
 
     // Only uglify in production, because
     // this doubles build time locally!

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,9 +62,9 @@ gulp.task('js', function () {
         ]
     });
 
-    // Only uglify in production, because
-    // this doubles build time locally!
-    if (process.env.NODE_ENV === 'production') {
+    // Only uglify for deployment/production build,
+    // because this doubles build time locally!
+    if (process.env.NODE_ENV === 'deployment') {
         return bundle.bundle()
             .pipe(plumber())
             .pipe(source('tangram-play.js'))

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "postinstall": "ln -nsf ../src/js node_modules/app",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "jshint *.js src/ || true; jscs *.js src/ || true",
     "build": "modernizr -c modernizr-config.json -d build/js; gulp build"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
   ],
   "devDependencies": {
     "autoprefixer": "^6.0.3",
-    "babelify": "^6.4.0",
-    "browserify": "^11.2.0",
+    "babel-preset-es2015": "^6.6.0",
+    "babelify": "^7.2.0",
+    "browserify": "^13.0.0",
     "browserify-shim": "^3.8.11",
     "csswring": "^4.0.0",
     "gulp": "^3.9.0",
@@ -58,8 +59,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
-    "babel": "^5.8.29",
-    "babel-runtime": "5.8.29",
+    "babel-polyfill": "^6.7.4",
     "clipboard": "^1.5.5",
     "codemirror": "5.12.0",
     "gsap": "^1.18.0",
@@ -67,6 +67,11 @@
     "leaflet-hash": "^0.2.1",
     "whatwg-fetch": "^0.11.0",
     "xhr": "^2.2.0"
+  },
+  "browserify": {
+    "transform": [
+      "browserify-shim"
+    ]
   },
   "browserify-shim": {
     "tangram": "global:Tangram",

--- a/package.json
+++ b/package.json
@@ -67,11 +67,6 @@
     "whatwg-fetch": "^0.11.0",
     "xhr": "^2.2.0"
   },
-  "browserify": {
-    "transform": [
-      "browserify-shim"
-    ]
-  },
   "browserify-shim": {
     "tangram": "global:Tangram",
     "./src/js/vendor/colors.js": "Colors"

--- a/src/js/TangramPlay.js
+++ b/src/js/TangramPlay.js
@@ -3,27 +3,27 @@ import 'babel-polyfill';
 import 'whatwg-fetch';
 
 // Core elements
-import Map from 'app/core/map';
-import { initEditor } from 'app/core/editor';
+import Map from './core/map';
+import { initEditor } from './core/editor';
 
 // Addons
-import UI from 'app/addons/UI';
-import MapLoading from 'app/addons/ui/MapLoading';
-import Modal from 'app/addons/ui/Modal';
-import WidgetsManager from 'app/addons/WidgetsManager';
-import SuggestManager from 'app/addons/SuggestManager';
-import GlslSandbox from 'app/addons/GLSLSandbox';
-import GlslHelpers from 'app/addons/GLSLHelpers';
-import ErrorsManager from 'app/addons/ErrorsManager';
-import ColorPalette from 'app/addons/ColorPalette';
-import LocalStorage from 'app/addons/LocalStorage';
+import UI from './addons/UI';
+import MapLoading from './addons/ui/MapLoading';
+import Modal from './addons/ui/Modal';
+import WidgetsManager from './addons/WidgetsManager';
+import SuggestManager from './addons/SuggestManager';
+import GlslSandbox from './addons/GLSLSandbox';
+import GlslHelpers from './addons/GLSLHelpers';
+import ErrorsManager from './addons/ErrorsManager';
+import ColorPalette from './addons/ColorPalette';
+import LocalStorage from './addons/LocalStorage';
 
 // Import Utils
 import xhr from 'xhr';
-import { subscribeMixin } from 'app/tools/mixin';
-import { StopWatch, debounce, createObjectURL } from 'app/tools/common';
-import { selectLines, isStrEmpty } from 'app/core/codemirror/tools';
-import { getNodes, parseYamlString } from 'app/core/codemirror/yaml-tangram';
+import { subscribeMixin } from './tools/mixin';
+import { StopWatch, debounce, createObjectURL } from './tools/common';
+import { selectLines, isStrEmpty } from './core/codemirror/tools';
+import { getNodes, parseYamlString } from './core/codemirror/yaml-tangram';
 
 const query = parseQuery(window.location.search.slice(1));
 

--- a/src/js/TangramPlay.js
+++ b/src/js/TangramPlay.js
@@ -1,4 +1,5 @@
 // Polyfills
+import 'babel-polyfill';
 import 'whatwg-fetch';
 
 // Core elements

--- a/src/js/addons/ColorPalette.js
+++ b/src/js/addons/ColorPalette.js
@@ -1,8 +1,8 @@
-import TangramPlay from 'app/TangramPlay';
+import TangramPlay from '../TangramPlay';
 
-import ColorPicker from 'app/addons/pickers/ColorPicker';
-import { toCSS } from 'app/tools/common';
-import { jumpToLine } from 'app/core/codemirror/tools';
+import ColorPicker from './pickers/ColorPicker';
+import { toCSS } from '../tools/common';
+import { jumpToLine } from '../core/codemirror/tools';
 
 export default class ColorPalette {
     constructor() {

--- a/src/js/addons/ErrorsManager.js
+++ b/src/js/addons/ErrorsManager.js
@@ -1,4 +1,4 @@
-import TangramPlay from 'app/TangramPlay';
+import TangramPlay from '../TangramPlay';
 
 export default class ErrorsManager {
     constructor() {

--- a/src/js/addons/GLSLHelpers.js
+++ b/src/js/addons/GLSLHelpers.js
@@ -1,9 +1,9 @@
-import TangramPlay from 'app/TangramPlay';
+import TangramPlay from '../TangramPlay';
 
-import ColorPicker from 'app/addons/pickers/ColorPicker';
-import Vec3Picker from 'app/addons/pickers/Vec3Picker';
-import Vec2Picker from 'app/addons/pickers/Vec2Picker';
-import FloatPicker from 'app/addons/pickers/FloatPicker';
+import ColorPicker from './pickers/ColorPicker';
+import Vec3Picker from './pickers/Vec3Picker';
+import Vec2Picker from './pickers/Vec2Picker';
+import FloatPicker from './pickers/FloatPicker';
 
 // Return all pattern matches with captured groups
 RegExp.prototype.execAll = function(string) {

--- a/src/js/addons/GLSLSandbox.js
+++ b/src/js/addons/GLSLSandbox.js
@@ -1,10 +1,10 @@
-import TangramPlay from 'app/TangramPlay';
+import TangramPlay from '../TangramPlay';
 
-import { debounce, getDOMOffset } from 'app/tools/common';
-import { isEmpty } from 'app/core/codemirror/tools';
-import { isNormalBlock, isColorBlock, getAddressSceneContent, getKeysFromAddress } from 'app/core/codemirror/yaml-tangram';
+import { debounce, getDOMOffset } from '../tools/common';
+import { isEmpty } from '../core/codemirror/tools';
+import { isNormalBlock, isColorBlock, getAddressSceneContent, getKeysFromAddress } from '../core/codemirror/yaml-tangram';
 
-import ColorPicker from 'app/addons/pickers/ColorPicker';
+import ColorPicker from './pickers/ColorPicker';
 
 /* global GlslCanvas */
 

--- a/src/js/addons/SuggestManager.js
+++ b/src/js/addons/SuggestManager.js
@@ -1,8 +1,8 @@
-import TangramPlay from 'app/TangramPlay';
+import TangramPlay from '../TangramPlay';
 
 // Load some common functions
-import { getLineInd, isCommented, isEmpty, regexEscape } from 'app/core/codemirror/tools';
-import { getAddressSceneContent, getAddressForLevel } from 'app/core/codemirror/yaml-tangram';
+import { getLineInd, isCommented, isEmpty, regexEscape } from '../core/codemirror/tools';
+import { getAddressSceneContent, getAddressForLevel } from '../core/codemirror/yaml-tangram';
 
 // Import CodeMirror
 import CodeMirror from 'codemirror';

--- a/src/js/addons/UI.js
+++ b/src/js/addons/UI.js
@@ -1,8 +1,8 @@
-import FileDrop from 'app/addons/ui/FileDrop';
-import Menu from 'app/addons/ui/Menu';
-import Divider from 'app/addons/ui/Divider';
-import Tooltip from 'app/addons/ui/Tooltip';
-import MapToolbar from 'app/addons/ui/MapToolbar';
+import FileDrop from './ui/FileDrop';
+import Menu from './ui/Menu';
+import Divider from './ui/Divider';
+import Tooltip from './ui/Tooltip';
+import MapToolbar from './ui/MapToolbar';
 
 export default class UI {
     constructor () {

--- a/src/js/addons/WidgetsManager.js
+++ b/src/js/addons/WidgetsManager.js
@@ -1,11 +1,11 @@
-import TangramPlay from 'app/TangramPlay';
+import TangramPlay from '../TangramPlay';
 
 // Load some common functions
-import { subscribeMixin } from 'app/tools/mixin';
-import { isStrEmpty } from 'app/core/codemirror/tools';
+import { subscribeMixin } from '../tools/mixin';
+import { isStrEmpty } from '../core/codemirror/tools';
 
 // Load addons modules
-import WidgetType from 'app/addons/widgets/WidgetType';
+import WidgetType from './widgets/WidgetType';
 
 export default class WidgetsManager {
     constructor (configFile) {

--- a/src/js/addons/map/bookmarks.js
+++ b/src/js/addons/map/bookmarks.js
@@ -1,6 +1,6 @@
-import { map, container } from 'app/TangramPlay';
-import LocalStorage from 'app/addons/LocalStorage';
-import Modal from 'app/addons/ui/Modal';
+import { map, container } from '../../TangramPlay';
+import LocalStorage from '../LocalStorage';
+import Modal from '../ui/Modal';
 
 const STORAGE_BOOKMARKS_KEY = 'bookmarks';
 const DEFAULT_BOOKMARKS_OBJECT = {

--- a/src/js/addons/map/geolocator.js
+++ b/src/js/addons/map/geolocator.js
@@ -1,5 +1,5 @@
-import { map } from 'app/TangramPlay';
-import Modal from 'app/addons/ui/Modal';
+import { map } from '../../TangramPlay';
+import Modal from '../ui/Modal';
 
 let buttonEl;
 

--- a/src/js/addons/map/search.js
+++ b/src/js/addons/map/search.js
@@ -1,7 +1,7 @@
-import TangramPlay from 'app/TangramPlay';
-import { map, container } from 'app/TangramPlay';
-import { httpGet, debounce } from 'app/tools/common';
-import bookmarks from 'app/addons/map/bookmarks';
+import TangramPlay from '../../TangramPlay';
+import { map, container } from '../../TangramPlay';
+import { httpGet, debounce } from '../../tools/common';
+import bookmarks from './bookmarks';
 
 const PELIAS_KEY = 'search-xFAc9NI';
 const PELIAS_HOST = 'search.mapzen.com';

--- a/src/js/addons/pickers/ColorPicker.js
+++ b/src/js/addons/pickers/ColorPicker.js
@@ -1,9 +1,9 @@
 import Picker from './Picker';
 import Color from './types/Color';
 import { addEvent, removeEvent } from './Picker';
-import { getDevicePixelRatio } from 'app/tools/common';
+import { getDevicePixelRatio } from '../../tools/common';
 
-import { subscribeInteractiveDom } from 'app/tools/interactiveDom';
+import { subscribeInteractiveDom } from '../../tools/interactiveDom';
 
 // Some common use variables
 let startPoint;

--- a/src/js/addons/pickers/Picker.js
+++ b/src/js/addons/pickers/Picker.js
@@ -1,7 +1,7 @@
-import { getDevicePixelRatio } from 'app/tools/common';
-import { subscribeMixin } from 'app/tools/mixin';
+import { getDevicePixelRatio } from '../../tools/common';
+import { subscribeMixin } from '../../tools/mixin';
 
-import { subscribeInteractiveDom } from 'app/tools/interactiveDom';
+import { subscribeInteractiveDom } from '../../tools/interactiveDom';
 
 export default class Picker {
     constructor (CSS_PREFIX, properties) {

--- a/src/js/addons/ui/Divider.js
+++ b/src/js/addons/ui/Divider.js
@@ -1,6 +1,6 @@
-import TangramPlay from 'app/TangramPlay';
-import { map, editor } from 'app/TangramPlay';
-import LocalStorage from 'app/addons/LocalStorage';
+import TangramPlay from '../../TangramPlay';
+import { map, editor } from '../../TangramPlay';
+import LocalStorage from '../LocalStorage';
 
 // Import Greensock (GSAP)
 import 'gsap/src/uncompressed/TweenLite.js';

--- a/src/js/addons/ui/EditorIO.js
+++ b/src/js/addons/ui/EditorIO.js
@@ -1,7 +1,7 @@
-import TangramPlay, { editor } from 'app/TangramPlay';
-import { saveAs } from 'app/vendor/FileSaver.min.js';
-import { noop } from 'app/addons/ui/Helpers';
-import Modal from 'app/addons/ui/Modal';
+import TangramPlay, { editor } from '../../TangramPlay';
+import { saveAs } from '../../vendor/FileSaver.min.js';
+import { noop } from '../ui/Helpers';
+import Modal from '../ui/Modal';
 
 const NEW_SCENE_PATH = 'data/scenes/empty.yaml';
 

--- a/src/js/addons/ui/FileDrop.js
+++ b/src/js/addons/ui/FileDrop.js
@@ -1,5 +1,5 @@
-import TangramPlay from 'app/TangramPlay';
-import EditorIO from 'app/addons/ui/EditorIO';
+import TangramPlay from '../../TangramPlay';
+import EditorIO from './EditorIO';
 
 export default class FileDrop {
     constructor () {

--- a/src/js/addons/ui/FileOpen.js
+++ b/src/js/addons/ui/FileOpen.js
@@ -1,4 +1,4 @@
-import EditorIO from 'app/addons/ui/EditorIO';
+import EditorIO from './EditorIO';
 
 export default class FileOpen {
     constructor () {

--- a/src/js/addons/ui/MapLoading.js
+++ b/src/js/addons/ui/MapLoading.js
@@ -1,4 +1,4 @@
-import { debounce } from 'app/tools/common';
+import { debounce } from '../../tools/common';
 
 const MapLoading = {
     el: document.getElementById('map-loading'),

--- a/src/js/addons/ui/MapToolbar.js
+++ b/src/js/addons/ui/MapToolbar.js
@@ -1,8 +1,8 @@
-import LocalStorage from 'app/addons/LocalStorage';
-import { map, container } from 'app/TangramPlay';
-import search from 'app/addons/map/search';
-import geolocator from 'app/addons/map/geolocator';
-import bookmarks from 'app/addons/map/bookmarks';
+import LocalStorage from '../LocalStorage';
+import { map, container } from '../../TangramPlay';
+import search from '../map/search';
+import geolocator from '../map/geolocator';
+import bookmarks from '../map/bookmarks';
 
 const STORAGE_DISPLAY_KEY = 'map-toolbar-display';
 const MAP_UPDATE_DELTA = 0.002;

--- a/src/js/addons/ui/Menu.js
+++ b/src/js/addons/ui/Menu.js
@@ -1,12 +1,12 @@
-import TangramPlay, { container, map } from 'app/TangramPlay';
-import { noop } from 'app/addons/ui/Helpers';
-import EditorIO from 'app/addons/ui/EditorIO';
-import FileOpen from 'app/addons/ui/FileOpen';
-import ExamplesModal from 'app/addons/ui/Modal.Examples';
-import OpenURLModal from 'app/addons/ui/Modal.OpenURL';
-import AboutModal from 'app/addons/ui/Modal.About';
-import SaveGistModal from 'app/addons/ui/Modal.SaveToGist';
-import fullscreen from 'app/addons/ui/fullscreen';
+import TangramPlay, { container, map } from '../../TangramPlay';
+import { noop } from './Helpers';
+import EditorIO from './EditorIO';
+import FileOpen from './FileOpen';
+import ExamplesModal from './Modal.Examples';
+import OpenURLModal from './Modal.OpenURL';
+import AboutModal from './Modal.About';
+import SaveGistModal from './Modal.SaveToGist';
+import fullscreen from './fullscreen';
 
 export default class Menu {
     constructor () {

--- a/src/js/addons/ui/Modal.About.js
+++ b/src/js/addons/ui/Modal.About.js
@@ -1,5 +1,5 @@
-import { container } from 'app/TangramPlay';
-import Modal from 'app/addons/ui/Modal';
+import { container } from '../../TangramPlay';
+import Modal from './Modal';
 import CodeMirror from 'codemirror';
 
 let modalEl;

--- a/src/js/addons/ui/Modal.Examples.js
+++ b/src/js/addons/ui/Modal.Examples.js
@@ -1,6 +1,6 @@
-import TangramPlay, { container } from 'app/TangramPlay';
-import Modal from 'app/addons/ui/Modal';
-import EditorIO from 'app/addons/ui/EditorIO';
+import TangramPlay, { container } from '../../TangramPlay';
+import Modal from './Modal';
+import EditorIO from './EditorIO';
 
 let examplesEl;
 

--- a/src/js/addons/ui/Modal.OpenURL.js
+++ b/src/js/addons/ui/Modal.OpenURL.js
@@ -1,6 +1,6 @@
-import TangramPlay, { container } from 'app/TangramPlay';
-import Modal from 'app/addons/ui/Modal';
-import EditorIO from 'app/addons/ui/EditorIO';
+import TangramPlay, { container } from '../../TangramPlay';
+import Modal from './Modal';
+import EditorIO from './EditorIO';
 
 let modalEl;
 

--- a/src/js/addons/ui/Modal.SaveToGist.js
+++ b/src/js/addons/ui/Modal.SaveToGist.js
@@ -1,6 +1,6 @@
-import TangramPlay, { container, editor } from 'app/TangramPlay';
-import LocalStorage from 'app/addons/LocalStorage';
-import Modal from 'app/addons/ui/Modal';
+import TangramPlay, { container, editor } from '../../TangramPlay';
+import LocalStorage from '../LocalStorage';
+import Modal from './Modal';
 import xhr from 'xhr';
 import Clipboard from 'clipboard';
 

--- a/src/js/addons/ui/Modal.js
+++ b/src/js/addons/ui/Modal.js
@@ -1,6 +1,6 @@
-import { container } from 'app/TangramPlay';
-import shield from 'app/addons/ui/shield';
-import { noop } from 'app/addons/ui/Helpers';
+import { container } from '../../TangramPlay';
+import shield from './shield';
+import { noop } from './Helpers';
 
 export default class Modal {
     constructor (message, confirm = noop, abort = noop, options = {}) {

--- a/src/js/addons/widgets/ColorButton.js
+++ b/src/js/addons/widgets/ColorButton.js
@@ -1,6 +1,6 @@
-import Widget from 'app/addons/widgets/Widget';
-import ColorPicker from 'app/addons/pickers/ColorPicker';
-import { toCSS, toColorVec } from 'app/tools/common';
+import Widget from './Widget';
+import ColorPicker from '../pickers/ColorPicker';
+import { toCSS, toColorVec } from '../../tools/common';
 
 // When presenting the modal, offset X, Y of the the modal by
 // these values, in pixels

--- a/src/js/addons/widgets/DropDownMenu.js
+++ b/src/js/addons/widgets/DropDownMenu.js
@@ -1,6 +1,6 @@
-import TangramPlay from 'app/TangramPlay';
-import Widget from 'app/addons/widgets/Widget';
-import { getAddressSceneContent } from 'app/core/codemirror/yaml-tangram';
+import TangramPlay from '../../TangramPlay';
+import Widget from './Widget';
+import { getAddressSceneContent } from '../../core/codemirror/yaml-tangram';
 
 export default class DropDownMenu extends Widget {
     createEl () {

--- a/src/js/addons/widgets/ToggleButton.js
+++ b/src/js/addons/widgets/ToggleButton.js
@@ -1,4 +1,4 @@
-import Widget from 'app/addons/widgets/Widget.js';
+import Widget from './Widget.js';
 
 export default class ToggleButton extends Widget {
     createEl (key) {

--- a/src/js/addons/widgets/VectorButton.js
+++ b/src/js/addons/widgets/VectorButton.js
@@ -1,5 +1,5 @@
-import Widget from 'app/addons/widgets/Widget.js';
-import Vec3Picker from 'app/addons/pickers/Vec3Picker';
+import Widget from './Widget.js';
+import Vec3Picker from '../pickers/Vec3Picker';
 
 // When presenting the modal, offset X, Y of the the modal by
 // these values, in pixels

--- a/src/js/addons/widgets/Widget.js
+++ b/src/js/addons/widgets/Widget.js
@@ -8,8 +8,8 @@
  *
  */
 
-import TangramPlay from 'app/TangramPlay';
-import { editor } from 'app/TangramPlay';
+import TangramPlay from '../../TangramPlay';
+import { editor } from '../../TangramPlay';
 
 export default class Widget {
     constructor (def, node) {

--- a/src/js/addons/widgets/WidgetType.js
+++ b/src/js/addons/widgets/WidgetType.js
@@ -1,7 +1,7 @@
-import ColorButton from 'app/addons/widgets/ColorButton';
-import ToggleButton from 'app/addons/widgets/ToggleButton';
-import DropDownMenu from 'app/addons/widgets/DropDownMenu';
-import VectorButton from 'app/addons/widgets/VectorButton';
+import ColorButton from './ColorButton';
+import ToggleButton from './ToggleButton';
+import DropDownMenu from './DropDownMenu';
+import VectorButton from './VectorButton';
 
 export default class WidgetType {
     constructor (datum) {

--- a/src/js/core/codemirror/hint-tangram.js
+++ b/src/js/core/codemirror/hint-tangram.js
@@ -1,4 +1,4 @@
-import TangramPlay from 'app/TangramPlay';
+import TangramPlay from '../../TangramPlay';
 import CodeMirror from 'codemirror';
 
 CodeMirror.registerHelper('hint', 'yaml', function (editor, options) {

--- a/src/js/core/codemirror/tools.js
+++ b/src/js/core/codemirror/tools.js
@@ -1,4 +1,4 @@
-import { isNumber } from 'app/tools/common';
+import { isNumber } from '../../tools/common';
 
 //  GET Functions
 //  ===============================================================================

--- a/src/js/core/codemirror/yaml-tangram.js
+++ b/src/js/core/codemirror/yaml-tangram.js
@@ -1,9 +1,9 @@
 import CodeMirror from 'codemirror';
 import 'codemirror/mode/yaml/yaml.js';
-import 'app/core/codemirror/glsl-tangram';
+import '../codemirror/glsl-tangram';
 
 // Load some common functions
-import { getInd } from 'app/core/codemirror/tools';
+import { getInd } from '../codemirror/tools';
 
 //  GET public functions
 //  ===============================================================================

--- a/src/js/core/editor.js
+++ b/src/js/core/editor.js
@@ -28,7 +28,7 @@ import './codemirror/hint-tangram';
 import 'codemirror/keymap/sublime';
 
 // Import Utils
-import { getLineInd, unfoldAll, foldByLevel } from 'app/core/codemirror/tools';
+import { getLineInd, unfoldAll, foldByLevel } from './codemirror/tools';
 
 //  Main CM functions
 //  ===============================================================================

--- a/src/js/core/editor.js
+++ b/src/js/core/editor.js
@@ -1,5 +1,5 @@
 // Import TangramPlay
-import TangramPlay from 'app/TangramPlay';
+import TangramPlay from '../TangramPlay';
 
 // Import CodeMirror
 import CodeMirror from 'codemirror';
@@ -21,8 +21,8 @@ import 'codemirror/addon/display/panel';
 import 'codemirror/mode/javascript/javascript';
 
 // Import additional parsers
-import 'app/core/codemirror/comment-tangram';
-import 'app/core/codemirror/hint-tangram';
+import './codemirror/comment-tangram';
+import './codemirror/hint-tangram';
 
 // Keymap
 import 'codemirror/keymap/sublime';

--- a/src/js/core/map.js
+++ b/src/js/core/map.js
@@ -1,11 +1,11 @@
-import TangramPlay from 'app/TangramPlay';
+import TangramPlay from '../TangramPlay';
 
-import LocalStorage from 'app/addons/LocalStorage';
-import MapLoading from 'app/addons/ui/MapLoading';
+import LocalStorage from '../addons/LocalStorage';
+import MapLoading from '../addons/ui/MapLoading';
 
 import L from 'leaflet';
 import 'leaflet-hash';
-import { saveAs } from 'app/vendor/FileSaver.min.js';
+import { saveAs } from '../vendor/FileSaver.min.js';
 
 export default class Map {
     constructor (mapElement) {


### PR DESCRIPTION
The only way I can reliably update to babel6 and avoid the `SyntaxError: 'import' and 'export' may appear only with 'sourceType: module'` error message is to convert all imports to relative paths rather than ones symlinked from a `node_modules/app` directory. This _may_ be a function of how babelify implements babel6; it assumes anything in `node_modules` is an actual module (and not a fake one, as we've done here, following this example from the [Browserify handbook](https://github.com/substack/browserify-handbook#avoiding-)) so when we try to force the issue, it will attempt to convert _all_ node modules to Babel, which is also not something we want.

If we're okay with doing relative paths everywhere (and I can see that in some modules we are already doing this anyway, so this was already inconsistent across this project) then this can be merged and the upgrade to Babel 6 completed.