### PR TITLE
Use glslCanvas from npm package instead of rawgit script

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,9 +226,6 @@
 
     <script type='text/javascript' src='https://mapzen.com/tangram/0.7/tangram.min.js'></script>
 
-    <!-- Glsl Sandbox in a canvas -->
-    <script type='text/javascript' src='https://rawgit.com/patriciogonzalezvivo/glslCanvas/master/build/GlslCanvas.min.js'></script>
-
     <!-- IDE -->
     <script type="text/javascript" src="build/js/tangram-play.js"></script>
     <script>

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-polyfill": "^6.7.4",
     "clipboard": "^1.5.5",
     "codemirror": "5.13.2",
+    "glslCanvas": "0.0.9",
     "gsap": "^1.18.0",
     "leaflet": "^1.0.0-beta.2",
     "leaflet-hash": "^0.2.1",

--- a/src/js/glsl/sandbox.js
+++ b/src/js/glsl/sandbox.js
@@ -7,7 +7,7 @@ import { isNormalBlock, isColorBlock, getAddressSceneContent, getKeysFromAddress
 
 import ColorPicker from '../pickers/color';
 
-/* global GlslCanvas */
+import GlslCanvas from 'glslCanvas';
 
 (function() {
     var lastTime = 0;


### PR DESCRIPTION
Rawgit went down today (see #293) taking Tangram Play functionality with it for about ~30 minutes. This was one of the Rawgit dependencies, which we can change to using npm packages now that it is one.