### PR TITLE
Do stuff with URLs.

### DIFF
--- a/src/js/modals/modal.open-url.js
+++ b/src/js/modals/modal.open-url.js
@@ -2,21 +2,15 @@ import TangramPlay from '../tangram-play';
 import Modal from './modal';
 import ErrorModal from './modal.error';
 import EditorIO from '../editor/io';
-import { isGistURL, getSceneURLFromGistAPI } from '../tools/gist-url';
 
 class OpenUrlModal extends Modal {
     constructor () {
         const message = 'Open a scene file from URL';
         const onConfirm = () => {
-            let value = this.input.value.trim();
+            this.waitStateOn();
 
-            // If it appears to be a Gist URL:
-            if (isGistURL(value) === true) {
-                this.fetchGistURL(value);
-            }
-            else {
-                this.openUrl(value);
-            }
+            const value = this.input.value.trim();
+            this.openUrl(value);
         };
         const onAbort = () => {
             this.clearInput();
@@ -28,14 +22,12 @@ class OpenUrlModal extends Modal {
 
         this.input = this.el.querySelector('.open-url-input input');
         this.input.addEventListener('keyup', (event) => {
-            // Check for valid URL.
-            // Reported as valid by the form element AND
-            // either ends with a YAML extension or matches a Gist URL
-            if (this.input.value && this.input.validity.valid === true &&
-                (this.input.value.match(/\.y(a?)ml$/) ||
-                isGistURL(this.input.value))) {
+            // We no longer check for valid URL signatures.
+            // It is easier to attempt to fetch an input URL and see what happens.
+            if (this.input.value) {
                 this.el.querySelector('.modal-confirm').removeAttribute('disabled');
-                let key = event.keyCode || event.which;
+
+                const key = event.keyCode || event.which;
                 if (key === 13) {
                     this._handleConfirm();
                 }
@@ -73,22 +65,10 @@ class OpenUrlModal extends Modal {
         this.options.disableEsc = false;
     }
 
-    fetchGistURL (url) {
-        this.waitStateOn();
-
-        getSceneURLFromGistAPI(url)
-            .then(url => {
-                this.openUrl(url);
-            })
-            .catch(error => {
-                this.onGetError(error);
-            });
-    }
-
     openUrl (url) {
         this.waitStateOff();
         this.clearInput();
-        TangramPlay.load({ url: url });
+        TangramPlay.load({ url });
     }
 
     /**

--- a/src/js/modals/modal.save-gist.js
+++ b/src/js/modals/modal.save-gist.js
@@ -4,6 +4,7 @@ import Modal from './modal';
 import ErrorModal from './modal.error';
 import Clipboard from 'clipboard';
 import { getScreenshotData } from '../map/map';
+import { getQueryStringObject, serializeToQueryString } from '../tools/helpers';
 
 const DEFAULT_GIST_SCENE_FILENAME = 'scene.yaml';
 const DEFAULT_GIST_DESCRIPTION = 'This is a Tangram scene, made with Tangram Play.';
@@ -160,6 +161,16 @@ class SaveGistModal extends Modal {
 
         // Mark as clean state in the editor
         editor.doc.markClean();
+
+        // Update the page URL. The scene parameter should
+        // reflect the new scene URL.
+        // TODO: Combine with similar functionality in
+        // tangram-play.js updateContent()
+        const queryObj = getQueryStringObject();
+        queryObj.scene = gist.url;
+        const url = window.location.href.split('?')[0];
+        const queryString = serializeToQueryString(queryObj);
+        window.history.replaceState({}, null, url + queryString + window.location.hash);
 
         // Show success modal
         let SaveGistSuccessModal = new Modal(undefined, undefined, undefined, { el: document.body.querySelector('.save-gist-success-modal') });

--- a/src/js/modals/modal.save-gist.js
+++ b/src/js/modals/modal.save-gist.js
@@ -168,7 +168,7 @@ class SaveGistModal extends Modal {
         // tangram-play.js updateContent()
         const queryObj = getQueryStringObject();
         queryObj.scene = gist.url;
-        const url = window.location.href.split('?')[0];
+        const url = window.location.pathname;
         const queryString = serializeToQueryString(queryObj);
         window.history.replaceState({}, null, url + queryString + window.location.hash);
 

--- a/src/js/modals/modal.save-gist.js
+++ b/src/js/modals/modal.save-gist.js
@@ -9,7 +9,7 @@ import { getQueryStringObject, serializeToQueryString } from '../tools/helpers';
 const DEFAULT_GIST_SCENE_FILENAME = 'scene.yaml';
 const DEFAULT_GIST_DESCRIPTION = 'This is a Tangram scene, made with Tangram Play.';
 const STORAGE_SAVED_GISTS = 'gists';
-const SAVE_TIMEOUT = 6000; // ms before we assume saving is failure
+const SAVE_TIMEOUT = 20000; // ms before we assume saving is failure
 
 class SaveGistModal extends Modal {
     constructor () {
@@ -106,8 +106,9 @@ class SaveGistModal extends Modal {
                 });
 
                 // Start save timeout
+                // TODO: This does not cancel the request if it is in progress
                 this._timeout = window.setTimeout(() => {
-                    this.onSaveError('GitHub’s servers haven’t responded in a while, so we’re going stop waiting for them. You might want to try again later!');
+                    this.onSaveError({ message: 'GitHub’s servers haven’t responded in a while, so we’re going stop waiting for them. You might want to try again later!' });
                 }, SAVE_TIMEOUT);
             });
         };

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -209,7 +209,9 @@ class TangramPlay {
         initialLoad = false;
 
         // Update history
-        let locationPrefix = '.';
+        // Can't do a pushstate where the URL includes 'http://localhost' due to security
+        // problems. So we have to let the browser do the routing relative to the server
+        let locationPrefix = window.location.pathname;
         if (scene.url) {
             locationPrefix += '?scene=' + scene.url;
         }
@@ -286,7 +288,7 @@ class TangramPlay {
         const queryObj = getQueryStringObject();
         if (queryObj.scene) {
             delete queryObj.scene;
-            const url = window.location.href.split('?')[0];
+            const url = window.location.pathname;
             const queryString = serializeToQueryString(queryObj);
             window.history.replaceState({}, null, url + queryString + window.location.hash);
         }

--- a/src/js/tools/gist-url.js
+++ b/src/js/tools/gist-url.js
@@ -63,12 +63,7 @@ export function getSceneURLFromGistAPI (url) {
     return window.fetch(url)
         .then(response => {
             if (!response.ok) {
-                if (response.status === 404) {
-                    throw new Error('This Gist could not be found.');
-                }
-                else {
-                    throw new Error(`The Gist server gave us an error code of ${response.status}`);
-                }
+                throw new Error(response.status);
             }
             return response.json();
         })

--- a/src/js/tools/helpers.js
+++ b/src/js/tools/helpers.js
@@ -19,8 +19,12 @@ export function getQueryStringObject (queryString = window.location.search) {
         const key = decodeURIComponent(keyValue[0]);
         const value = decodeURIComponent(keyValue[1]);
 
-        // Assign key and value to object
-        object[key] = value;
+        // Do not assign if key is a blank string or
+        // if value is undefined. Do not test for 'falsy'
+        // values, which are valid keys and values.
+        if (key !== '' && typeof value !== 'undefined') {
+            object[key] = value;
+        }
 
         return object;
     }, {});

--- a/src/js/tools/helpers.js
+++ b/src/js/tools/helpers.js
@@ -1,15 +1,71 @@
 export function returnTrue () {}
 
-export function parseQuery (qstr) {
-    let query = {};
-    let a = qstr.split('&');
-    for (let i in a) {
-        let b = a[i].split('=');
-        query[decodeURIComponent(b[0])] = decodeURIComponent(b[1]);
-    }
-    return query;
+/**
+ * Gets a deserialized object from the current window's URL.
+ * It breaks down the query string, e.g. '?scene=foo.yaml'
+ * into this: { scene: "foo.yaml" }
+ *
+ * @param {string} window.location.search
+ * @returns {Object} deserialized key-value pairs
+ */
+export function getQueryStringObject (queryString = window.location.search) {
+    // Slices off the initial '?' separator on the string,
+    // then splits the string into an array of key-value pairs
+    const arr = queryString.slice(1).split('&');
+
+    // For each key-value pair, deserialize to properties on a new object.
+    const queryObj = arr.reduce(function (object, pair) {
+        const keyValue = pair.split('=');
+        const key = decodeURIComponent(keyValue[0]);
+        const value = decodeURIComponent(keyValue[1]);
+
+        // Assign key and value to object
+        object[key] = value;
+
+        return object;
+    }, {});
+
+    // The lack of a query string should still return an empty
+    // object. This should not be undefined.
+    return queryObj;
 }
 
+/**
+ * Given an object of key-value pairs, serializes that object
+ * into a valid query string. It turns { scene: "foo.yaml", bar: "baz" }
+ * into '?scene=foo.yaml&bar=baz'
+ *
+ * @param {Object} set of key-value pairs
+ * @returns {string} valid facsimile for window.location.search
+ */
+export function serializeToQueryString (obj = {}) {
+    const str = [];
+    for (let p in obj) {
+        // Nulls or undefined is just empty string
+        if (obj[p] === null || typeof obj[p] === 'undefined') {
+            obj[p] = '';
+        }
+
+        if (obj.hasOwnProperty(p)) {
+            str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
+        }
+    }
+
+    // Returns a string prepended with '?' separator if
+    // key value pairs are provided; otherwise, returns
+    // an empty string. This allows URL-assemblage to
+    // "just work" if query string is empty.
+    return (str.length > 0) ? '?' + str.join('&') : '';
+}
+
+/**
+ * Empties a DOM element of all child nodes.
+ * Effectively identical to jQuery's $(el).empty()
+ * This is purportedly faster than clearning an element's
+ * innerHTML property, e.g. el.innerHTML = '';
+ *
+ * @param {Node} the element to empty
+ */
 export function emptyDOMElement (el) {
     while (el.firstChild) {
         el.removeChild(el.firstChild);


### PR DESCRIPTION
- Clears the `scene=` parameter after a url-loaded scene is edited. Resolves #253.
- Saving a gist also automatically updates the `scene=` parameter to make it easy to send the URL immediately after
- Typing a Gist URL into `scene=` parameter will also work now
- If Gists have been deleted (by e-mailing GitHub help department) they will also be removed automatically after receiving a 404 notice.