### PR TITLE
Repair parsing for drop down widgets; fix highlighting lines that have not been parsed by CodeMirror

### DIFF
--- a/src/js/editor/codemirror/yaml-tangram.js
+++ b/src/js/editor/codemirror/yaml-tangram.js
@@ -24,31 +24,30 @@ export function getNodes(cm, nLine) {
     }
 }
 
+/**
+ * Returns the content given an address
+ * If for any reason the content is not found, return an empty string
+ *
+ * @param {Object} tangramScene - Tangram's parsed object tree of scene content
+ * @param {string} address - in the form of 'key1:key2:key3'
+ * @return {mixed} content - Whatever is stored as a value for that key
+ */
 export function getAddressSceneContent(tangramScene, address) {
-    if (tangramScene && tangramScene.config) {
-        let keys = getKeysFromAddress(address);
-        if (keys && keys.length) {
-            let content = tangramScene.config[keys[0]];
-            if (content) {
-                for (let i = 1; i < keys.length; i++) {
-                    if (content[keys[i]]) {
-                        content = content[keys[i]];
-                    }
-                    else {
-                        return content;
-                    }
-                }
-                return content;
-            }
-            else {
-                return '';
-            }
-        }
-        else {
-            return '';
-        }
+    try {
+        const keys = getKeysFromAddress(address);
+
+        // Looks up content in Tangram's scene.config property.
+        // It's a nested object, so to look up from an array of nested keys,
+        // we reduce this array down to a single reference.
+        // e.g. ['a', 'b', 'c'] looks up content in
+        // tangramScene.config['a']['b']['c']
+        const content = keys.reduce((obj, property) => {
+            return obj[property];
+        }, tangramScene.config);
+
+        return content;
     }
-    else {
+    catch (error) {
         return '';
     }
 }

--- a/src/js/editor/codemirror/yaml-tangram.js
+++ b/src/js/editor/codemirror/yaml-tangram.js
@@ -53,15 +53,35 @@ export function getAddressSceneContent(tangramScene, address) {
     }
 }
 
-// Make an folder style address from an array of keys
+/**
+ * Return a string address from an array of key names
+ *
+ * @param {Array} keys - an array of keys
+ * @return {string} address - in the form of 'key1:key2:key3'
+ */
 function getAddressFromKeys (keys) {
     return keys.join(ADDRESS_KEY_DELIMITER);
 }
 
+/**
+ * Return an array of key names from an address
+ * An empty string will still return an array whose first item
+ * is the empty string.
+ *
+ * @param {string} address - in the form of 'key1:key2:key3'
+ * @return {Array} keys
+ */
 export function getKeysFromAddress (address) {
     return address.split(ADDRESS_KEY_DELIMITER);
 }
 
+/**
+ * Return a string address, truncated to a certain level
+ *
+ * @param {string} address  - in the form of 'key1:key2:key3'
+ * @param {Number} level - the level of address to obtain
+ * @return {string} address - truncated to maximum of `level`, e.g. 'key1:key2'
+ */
 export function getAddressForLevel (address, level) {
     const keys = getKeysFromAddress(address);
     const newKeys = keys.slice(0, level);
@@ -182,17 +202,18 @@ function getAnchorFromValue (value) {
 // }
 
 // Given a YAML string return an array of keys
+// TODO: We will need a different way of parsing YAML flow notation,
+// since this function does not cover the full range of legal YAML specification
 function getInlineNodes(str, nLine) {
     let rta = [];
     let stack = [];
     let i = 0;
-    let level = -1;
+    let level = 0;
 
     while (i < str.length) {
         let curr = str.substr(i, 1);
         if (curr === '{') {
             // Go one level up
-            stack.push(':');
             level++;
         }
         else if (curr === '}') {
@@ -218,6 +239,9 @@ function getInlineNodes(str, nLine) {
                 value = value.substr(anchor.length);
 
                 rta.push({
+                    // This gets an array starting at index 1. This means that the
+                    // result for address will come back as ':key1:key2:etc' because stack[0]
+                    // is undefined, but it will still be joined in getAddressFromKeys()
                     address: getAddressFromKeys(stack),
                     key: key,
                     value: value,

--- a/src/js/map/inspection.js
+++ b/src/js/map/inspection.js
@@ -268,11 +268,12 @@ class TangramInspectionPopup {
                     }
                     layerEl.classList.add('map-inspection-selected');
 
+                    // Scroll the top of the block into view. Do this first so that
+                    // CodeMirror will parse the lines in this viewport.
+                    jumpToLine(editor, node.range.from.line);
+
                     // Highlight the block.
                     highlightBlock(node, 'editor-inspection-highlight');
-
-                    // Scroll top of the block into view.
-                    jumpToLine(editor, node.range.from.line);
                 });
             }
             else {

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -78,8 +78,6 @@ function initTangram (pathToSceneFile) {
         }
     });
 
-    TangramPlay.trigger('sceneinit');
-
     window.layer = tangramLayer;
     window.scene = tangramLayer.scene;
 }

--- a/src/js/tangram-api.json
+++ b/src/js/tangram-api.json
@@ -182,7 +182,7 @@
                 "join",
                 "tile_edges"
             ],
-            "source": ":styles"
+            "source": "styles"
         },
         {
             "address": "^layers:(\\w|\\_|\\-|\\/)*:font$",
@@ -375,7 +375,7 @@
         {
             "address": "^styles:(\\w|\\_|\\-|\\/)+:mix$",
             "type": "string",
-            "source": ":styles"
+            "source": "styles"
         },
         {
             "address": "^styles:(\\w|\\_|\\-|\\/)+:blend$",
@@ -477,7 +477,7 @@
         {
             "address": "^layers:(\\w|\\_|\\-|\\/)+:data:source$",
             "type": "string",
-            "source": ":sources"
+            "source": "sources"
         },
         {
             "address": "^layers:(\\w|\\_|\\-|\\/)+:extrude$",
@@ -492,7 +492,7 @@
         {
             "address": "^layers:(\\w+|\\_|\\-|\\/):draw:(\\w|\\_|\\-|\\/)+:style$",
             "type": "string",
-            "source": ":styles",
+            "source": "styles",
             "options": [
                 "points",
                 "lines",

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -65,11 +65,23 @@ class TangramPlay {
             }
         };
 
-        setTimeout(() => {
+        // LOAD SCENE FILE
+        const initialScene = determineScene();
+        this.load(initialScene);
+
+        // Things we do after Tangram is finished initializing
+        tangramLayer.scene.initializing.then(() => {
+            this.trigger('sceneinit');
+
+            // Initialize addons after Tangram is done, because
+            // some addons depend on Tangram scene config being present
+            this.initAddons();
+
             if (query['lines']) {
-                this.selectLines(query['lines']);
+                // TODO: Highlight instead of select?
+                selectLines(this.editor, query['lines']);
             }
-        }, 500);
+        });
 
         // If the user bails for whatever reason, hastily shove the contents of
         // the editor into some kind of storage. This overwrites whatever was
@@ -411,11 +423,6 @@ class TangramPlay {
         }
         console.log('Fail searching', address);
     }
-
-    // Other actions
-    selectLines (strRange) {
-        selectLines(this.editor, strRange);
-    }
 }
 
 function showUnloadedState (editor) {
@@ -482,11 +489,6 @@ let tangramPlay = new TangramPlay();
 
 export default tangramPlay;
 export let editor = tangramPlay.editor;
-
-// LOAD SCENE FILE
-let scene = determineScene();
-tangramPlay.load(scene);
-tangramPlay.initAddons();
 
 // This is called here because right now divider position relies on
 // editor and map being set up already


### PR DESCRIPTION
Note: the inspiration for rewriting `getAddressSceneContent()` comes from here: http://blog.nicohaemhouts.com/2015/08/03/accessing-nested-javascript-objects-with-string-key/
