### PR TITLE
Export the `editor` object from its module

### DIFF
--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -19,6 +19,7 @@ import 'codemirror/addon/selection/active-line';
 import 'codemirror/mode/javascript/javascript';
 
 // Import additional parsers
+import './codemirror/yaml-tangram';
 import './codemirror/comment-tangram';
 import './codemirror/hint-tangram';
 
@@ -31,14 +32,17 @@ import { getLineInd, unfoldAll, foldByLevel } from './codemirror/tools';
 // Import Tangram Play functions
 import { takeScreenshot } from '../map/map';
 
-//  Main CM functions
+// Export CodeMirror instance
+export const editor = initCodeMirror(document.getElementById('editor'));
+
+//  CodeMirror
 //  ===============================================================================
 
-export function initEditor (id) {
+function initCodeMirror (el) {
     // Add rulers
-    let rulers = [];
+    const rulers = [];
     for (let i = 1; i < 10; i++) {
-        let b = Math.round((0.88 + i / 90) * 255);
+        const b = Math.round((0.88 + i / 90) * 255);
         rulers.push({
             color: 'rgba(' + b + ',' + b + ',' + b + ', 0.08)',
             column: i * 4,
@@ -46,11 +50,8 @@ export function initEditor (id) {
         });
     }
 
-    // Create DOM (TODO)
-    let dom = document.getElementById(id);
-
     // Initialize CodeMirror
-    let cm = CodeMirror(dom, {
+    const cm = new CodeMirror(el, {
         value: 'Loading...',
         rulers: rulers,
         styleActiveLine: true,

--- a/src/js/editor/errors.js
+++ b/src/js/editor/errors.js
@@ -1,3 +1,4 @@
+import { editor } from './editor';
 import TangramPlay from '../tangram-play';
 import { tangramLayer } from '../map/map';
 
@@ -8,7 +9,7 @@ export default class ErrorsManager {
         this.blockErrors = new Set();
 
         // EVENTS
-        TangramPlay.editor.on('changes', (cm, changesObjs) => {
+        editor.on('changes', (cm, changesObjs) => {
             TangramPlay.addons.errorsManager.clean();
         });
 
@@ -37,7 +38,7 @@ export default class ErrorsManager {
 
     clean() {
         for (let i = 0; i < this.widgets.length; i++) {
-            TangramPlay.editor.removeLineWidget(this.widgets[i]);
+            editor.removeLineWidget(this.widgets[i]);
         }
         this.widgets.length = 0;
         this.blockErrors.clear();
@@ -50,7 +51,7 @@ export default class ErrorsManager {
             icon.className = 'btm bt-exclamation-triangle error-icon';
             msg.appendChild(document.createTextNode(args.error.reason));
             msg.className = 'error';
-            this.widgets.push(TangramPlay.editor.addLineWidget(args.error.mark.line, msg, { coverGutter: false, noHScroll: true }));
+            this.widgets.push(editor.addLineWidget(args.error.mark.line, msg, { coverGutter: false, noHScroll: true }));
         }
     }
 
@@ -85,7 +86,7 @@ export default class ErrorsManager {
                     icon.className = 'btm bt-exclamation-circle warning-icon';
                     msg.appendChild(document.createTextNode(errors[i].message));
                     msg.className = 'warning';
-                    this.widgets.push(TangramPlay.editor.addLineWidget(nLine, msg, { coverGutter: false, noHScroll: true }));
+                    this.widgets.push(editor.addLineWidget(nLine, msg, { coverGutter: false, noHScroll: true }));
                     this.blockErrors.add(JSON.stringify(block)); // track unique errors
                 }
                 else {
@@ -102,7 +103,7 @@ export default class ErrorsManager {
                 icon.className = 'btm bt-exclamation-circle warning-icon';
                 msg.appendChild(document.createTextNode(`Duplicate key ${node.key} (${node.address})`));
                 msg.className = 'warning';
-                this.widgets.push(TangramPlay.editor.addLineWidget(nLine, msg, { coverGutter: false, noHScroll: true }));
+                this.widgets.push(editor.addLineWidget(nLine, msg, { coverGutter: false, noHScroll: true }));
             }
         }
     }

--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -1,4 +1,4 @@
-import { editor } from '../tangram-play';
+import { editor } from './editor';
 
 /**
  * Given a node, find all the lines that are part of that entire block, and then

--- a/src/js/editor/io.js
+++ b/src/js/editor/io.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import TangramPlay, { editor } from '../tangram-play';
+import TangramPlay from '../tangram-play';
+import { editor } from './editor';
 import { saveAs } from '../vendor/FileSaver.min.js';
 import Modal from '../modals/modal';
 

--- a/src/js/editor/suggest.js
+++ b/src/js/editor/suggest.js
@@ -1,3 +1,4 @@
+import { editor } from './editor';
 import TangramPlay from '../tangram-play';
 import TANGRAM_API from '../tangram-api.json';
 import { tangramLayer } from '../map/map';
@@ -31,8 +32,8 @@ export default class SuggestManager {
         TangramPlay.on('sceneupdate', (args) => {
             let bOpen = true;
 
-            let line = TangramPlay.editor.getCursor().line;
-            let stateAfter = TangramPlay.editor.getLineHandle(line).stateAfter;
+            let line = editor.getCursor().line;
+            let stateAfter = editor.getLineHandle(line).stateAfter;
             if (stateAfter && stateAfter.localMode && stateAfter.localMode.helperType) {
                 let helperType = stateAfter.localMode.helperType;
                 if (helperType === 'glsl' || helperType === 'javascript') {
@@ -40,13 +41,13 @@ export default class SuggestManager {
                 }
             }
 
-            if (isCommented(TangramPlay.editor, line) ||
-                isEmpty(TangramPlay.editor, line)) {
+            if (isCommented(editor, line) ||
+                isEmpty(editor, line)) {
                 bOpen = false;
             }
 
-            if (bOpen && TangramPlay.editor.showHint) {
-                TangramPlay.editor.showHint({
+            if (bOpen && editor.showHint) {
+                editor.showHint({
                     completeSingle: false,
                     alignWithWord: true,
                     closeCharacters: /[\s()\[\]{};:>,]/,
@@ -89,7 +90,7 @@ export default class SuggestManager {
         cursor.ch = cursor.ch - 1;
         // console.log("Cursor", cursor);
 
-        let range = TangramPlay.editor.findWordAt(cursor);
+        let range = editor.findWordAt(cursor);
         let from = range.anchor;
         let to = range.head;
         // console.log("RANGE",from,to);
@@ -134,7 +135,7 @@ export default class SuggestManager {
                 // console.log("List",list);
 
                 // What ever the list is suggest using it
-                let string = TangramPlay.editor.getRange(from, to);
+                let string = editor.getRange(from, to);
                 string = regexEscape(string);
 
                 // If the word is already begin to type, filter outcome
@@ -220,7 +221,7 @@ class Suggestion {
         if (node && this.checkAgainst) {
             let rightLevel = true;
             if (!forceLevel && this.level) {
-                rightLevel = getLineInd(TangramPlay.editor, node.pos.line) === this.level;
+                rightLevel = getLineInd(editor, node.pos.line) === this.level;
             }
             return RegExp(this.checkPatern).test(node[this.checkAgainst]) && rightLevel;
         }

--- a/src/js/glsl/helpers.js
+++ b/src/js/glsl/helpers.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { editor } from '../tangram-play';
+import { editor } from '../editor/editor';
 
 import ColorPicker from '../pickers/color';
 import Vec3Picker from '../pickers/vec3';

--- a/src/js/glsl/sandbox.js
+++ b/src/js/glsl/sandbox.js
@@ -1,4 +1,5 @@
 import TangramPlay from '../tangram-play';
+import { editor } from '../editor/editor';
 import { tangramLayer } from '../map/map';
 
 import { debounce, getDOMOffset } from '../tools/common';
@@ -87,21 +88,21 @@ export default class GlslSandbox {
         this.uniforms['u_vanishing_point'] = 1;
 
         // EVENTS
-        TangramPlay.editor.on('cursorActivity', function(cm) {
+        editor.on('cursorActivity', function(cm) {
             TangramPlay.addons.glslSandbox.onCursorMove();
         });
 
-        TangramPlay.editor.on('changes', function(cm, changesObj) {
+        editor.on('changes', function(cm, changesObj) {
             stopAction(cm);
         });
     }
 
     reload(nLine) {
         if (nLine === undefined) {
-            nLine = TangramPlay.editor.getCursor().line;
+            nLine = editor.getCursor().line;
         }
 
-        if (!isEmpty(TangramPlay.editor, nLine)) {
+        if (!isEmpty(editor, nLine)) {
             let keys = TangramPlay.getNodesOnLine(nLine);
             if (keys && keys[0]) {
                 this.address = keys[0].address;
@@ -122,7 +123,7 @@ export default class GlslSandbox {
                     if (this.shader === undefined) {
                         this.shader = new GlslCanvas(this.canvas);
                     }
-                    TangramPlay.editor.addWidget({ line: nLine, ch: 0 }, this.element);
+                    editor.addWidget({ line: nLine, ch: 0 }, this.element);
 
                     if (this.styleObj.shaders.uniforms) {
                         for (let name in this.styleObj.shaders.uniforms) {
@@ -257,7 +258,7 @@ export default class GlslSandbox {
     onColorClick (event) {
         let pos = getDOMOffset(this.colorPicker);
         pos.x += 30;
-        pos.y = TangramPlay.editor.heightAtLine(this.line) - 15;
+        pos.y = editor.heightAtLine(this.line) - 15;
 
         this.picker = new ColorPicker(this.colorPicker.style.backgroundColor);
 
@@ -275,10 +276,10 @@ export default class GlslSandbox {
     }
 
     onCursorMove() {
-        let pos = TangramPlay.editor.getCursor();
+        let pos = editor.getCursor();
 
-        let edge = TangramPlay.editor.charCoords({ line:pos.line, ch:20 }).left;
-        let left = TangramPlay.editor.charCoords(pos).left;
+        let edge = editor.charCoords({ line:pos.line, ch:20 }).left;
+        let left = editor.charCoords(pos).left;
 
         if (pos.ch < 20 || left < edge) {
             if (this.active) {

--- a/src/js/map/inspection.js
+++ b/src/js/map/inspection.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import L from 'leaflet';
 import { map } from './map';
 import { emptyDOMElement } from '../tools/helpers';
-import TangramPlay, { editor } from '../tangram-play';
+import TangramPlay from '../tangram-play';
+import { editor } from '../editor/editor';
 import { highlightBlock } from '../editor/highlight';
 import { jumpToLine } from '../editor/codemirror/tools';
 

--- a/src/js/modals/modal.save-gist.js
+++ b/src/js/modals/modal.save-gist.js
@@ -1,8 +1,9 @@
-import TangramPlay, { editor } from '../tangram-play';
+import TangramPlay from '../tangram-play';
 import LocalStorage from '../storage/localstorage';
 import Modal from './modal';
 import ErrorModal from './modal.error';
 import Clipboard from 'clipboard';
+import { editor } from '../editor/editor';
 import { map, getScreenshotData } from '../map/map';
 import { getLocationLabel } from '../map/search';
 import { getQueryStringObject, serializeToQueryString } from '../tools/helpers';

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -50,7 +50,6 @@ class TangramPlay {
     constructor () {
         subscribeMixin(this);
 
-        this.editor = editor;
         initMap();
         this.addons = {};
 
@@ -81,7 +80,7 @@ class TangramPlay {
 
                     if (query['lines']) {
                         // TODO: Highlight instead of select?
-                        selectLines(this.editor, query['lines']);
+                        selectLines(editor, query['lines']);
                     }
                 });
             });
@@ -100,9 +99,9 @@ class TangramPlay {
                 original_url: tangramLayer.scene.config_source,
                 original_base_path: tangramLayer.scene.config_path,
                 contents: this.getContent(),
-                is_clean: this.editor.isClean(),
-                scrollInfo: this.editor.getScrollInfo(),
-                cursor: this.editor.doc.getCursor()
+                is_clean: editor.isClean(),
+                scrollInfo: editor.getScrollInfo(),
+                cursor: editor.doc.getCursor()
             };
             saveSceneContentsToLocalMemory(sceneData);
         });
@@ -141,7 +140,7 @@ class TangramPlay {
         showSceneLoadingIndicator();
 
         // Turn off watching for changes in editor.
-        this.editor.off('changes', this._watchEditorForChanges);
+        editor.off('changes', this._watchEditorForChanges);
 
         // Either we are passed a url path, or scene file contents
         if (scene.url) {
@@ -203,8 +202,8 @@ class TangramPlay {
 
         // TODO: editor should not be attached to this
         if (initialLoad === true) {
-            showUnloadedState(this.editor);
-            this.editor.doc.markClean();
+            showUnloadedState(editor);
+            editor.doc.markClean();
         }
     }
 
@@ -251,8 +250,8 @@ class TangramPlay {
         let contents = suppressAPIKeys(sceneData.contents, config.TILES.API_KEYS.SUPPRESSED);
 
         // Set content in CodeMirror
-        this.editor.setValue(contents);
-        this.editor.clearHistory();
+        editor.setValue(contents);
+        editor.clearHistory();
 
         // Mark as "clean" if the contents are freshly loaded
         // (there is no is_clean property defined) or if contents
@@ -261,12 +260,12 @@ class TangramPlay {
         // a Boolean. Otherwise, the document has not been previously
         // saved and it is left in the "dirty" state.
         if (typeof sceneData['is_clean'] === 'undefined' || sceneData['is_clean'] === 'true') {
-            this.editor.doc.markClean();
+            editor.doc.markClean();
         }
 
         // Restore cursor position, if provided.
         if (sceneData.cursor) {
-            this.editor.doc.setCursor(sceneData.cursor, {
+            editor.doc.setCursor(sceneData.cursor, {
                 scroll: false
             });
         }
@@ -275,11 +274,11 @@ class TangramPlay {
         if (sceneData.scrollInfo) {
             let left = sceneData.scrollInfo.left || 0;
             let top = sceneData.scrollInfo.top || 0;
-            this.editor.scrollTo(left, top);
+            editor.scrollTo(left, top);
         }
 
         // Turn change watching back on.
-        this.editor.on('changes', this._watchEditorForChanges);
+        editor.on('changes', this._watchEditorForChanges);
     }
 
     // SET
@@ -300,7 +299,7 @@ class TangramPlay {
         let from = { line: node.range.from.line,
                      ch: node.range.from.ch + node.anchor.length + node.key.length + 2 };
 
-        this.editor.doc.replaceRange(str, from, node.range.to);
+        editor.doc.replaceRange(str, from, node.range.to);
     }
 
     // If editor is updated, send it to the map.
@@ -327,7 +326,7 @@ class TangramPlay {
     // GET
     // Get the contents of the editor (with injected API keys)
     getContent () {
-        let content = this.editor.getValue();
+        let content = editor.getValue();
         //  If API keys are missing, inject one
         content = injectAPIKey(content, config.TILES.API_KEYS.DEFAULT);
         return content;
@@ -376,10 +375,10 @@ class TangramPlay {
     }
 
     getNodesOnLine (nLine) {
-        if (isStrEmpty(this.editor.getLine(nLine))) {
+        if (isStrEmpty(editor.getLine(nLine))) {
             return [];
         }
-        return getNodes(this.editor, nLine);
+        return getNodes(editor, nLine);
     }
 
     getNodesForAddress (address) {
@@ -388,8 +387,8 @@ class TangramPlay {
         // address. Could be optimize if we store addresses in a map... but then the question is about how to keep it sync
         //
         let lastState;
-        for (let line = 0, size = this.editor.getDoc().size; line < size; line++) {
-            const lineHandle = this.editor.getLineHandle(line);
+        for (let line = 0, size = editor.getDoc().size; line < size; line++) {
+            const lineHandle = editor.getLineHandle(line);
 
             if (!lineHandle.stateAfter || !lineHandle.stateAfter.yamlState) {
                 // If the line is NOT parsed.

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -10,7 +10,7 @@ Raven.config('https://728949999d2a438ab006fed5829fb9c5@app.getsentry.com/78467',
 
 // Core elements
 import { tangramLayer, initMap, loadScene } from './map/map';
-import { initEditor } from './editor/editor';
+import { editor } from './editor/editor';
 import { config } from './config';
 
 // Addons
@@ -50,7 +50,7 @@ class TangramPlay {
     constructor () {
         subscribeMixin(this);
 
-        this.editor = initEditor('editor');
+        this.editor = editor;
         initMap();
         this.addons = {};
 
@@ -498,7 +498,6 @@ function getSceneContentsFromLocalMemory () {
 let tangramPlay = new TangramPlay();
 
 export default tangramPlay;
-export let editor = tangramPlay.editor;
 
 // This is called here because right now divider position relies on
 // editor and map being set up already

--- a/src/js/ui/divider.js
+++ b/src/js/ui/divider.js
@@ -1,4 +1,4 @@
-import { editor } from '../tangram-play';
+import { editor } from '../editor/editor';
 import LocalStorage from '../storage/localstorage';
 import { map } from '../map/map';
 

--- a/src/js/widgets/color-palette.js
+++ b/src/js/widgets/color-palette.js
@@ -1,5 +1,5 @@
 import TangramPlay from '../tangram-play';
-
+import { editor } from '../editor/editor';
 import ColorPicker from '../pickers/color';
 import { toCSS } from '../tools/common';
 import { jumpToLine } from '../editor/codemirror/tools';
@@ -25,10 +25,10 @@ export default class ColorPalette {
 
         // If is a new file load all colors by going to the end and comeback
         TangramPlay.on('sceneload', (event) => {
-            for (let i = 0; i < TangramPlay.editor.getDoc().size; i++) {
-                jumpToLine(TangramPlay.editor, i);
+            for (let i = 0; i < editor.getDoc().size; i++) {
+                jumpToLine(editor, i);
             }
-            jumpToLine(TangramPlay.editor, 0);
+            jumpToLine(editor, 0);
         });
     }
 
@@ -37,7 +37,7 @@ export default class ColorPalette {
         this.colors = {};
 
         // Find all bookmarks
-        let bookmarks = TangramPlay.editor.getDoc().getAllMarks();
+        let bookmarks = editor.getDoc().getAllMarks();
 
         // check for color picker widgets
         for (let bkm of bookmarks) {
@@ -100,7 +100,7 @@ class Color {
                 head: this.widgets[i].node.range.to
             });
         }
-        TangramPlay.editor.getDoc().setSelections(selections);
+        editor.getDoc().setSelections(selections);
     }
 
     onClick (event) {
@@ -134,7 +134,7 @@ class Color {
         // TODO: Store original value so we can go back to it if the
         // interaction is canceled.
         this.picker.on('changed', this.onPickerChange.bind(this));
-        TangramPlay.editor.focus();
+        editor.focus();
     }
 
     /**

--- a/src/js/widgets/widget.js
+++ b/src/js/widgets/widget.js
@@ -7,7 +7,8 @@
  *  with any additional functionality.
  *
  */
-import TangramPlay, { editor } from '../tangram-play';
+import TangramPlay from '../tangram-play';
+import { editor } from '../editor/editor';
 
 export default class Widget {
     constructor (def, node) {

--- a/src/js/widgets/widget.js
+++ b/src/js/widgets/widget.js
@@ -54,7 +54,7 @@ export default class Widget {
         // Find the right widget to update if a line has multiple nodes
         else {
             // Here is a good place to detect duplicates
-            // let others = TangramPlay.editor.getDoc().findMarksAt(this.node.range.to);
+            // let others = editor.getDoc().findMarksAt(this.node.range.to);
             let node = TangramPlay.getNodesForAddress(this.node.address);
             this.node = node;
         }
@@ -70,7 +70,7 @@ export default class Widget {
     insert () {
         this.updateNode();
 
-        let others = TangramPlay.editor.getDoc().findMarksAt(this.node.range.to);
+        let others = editor.getDoc().findMarksAt(this.node.range.to);
         if (others.length > 0) {
             console.log('Avoiding duplication');
             // if (TangramPlay.addons.errorsManager) {

--- a/src/js/widgets/widgets-manager.js
+++ b/src/js/widgets/widgets-manager.js
@@ -1,6 +1,7 @@
 import TangramPlay from '../tangram-play';
 import TANGRAM_API from '../tangram-api.json';
 import WidgetType from './widget-type';
+import { editor } from '../editor/editor';
 import { subscribeMixin } from '../tools/mixin';
 import { isStrEmpty } from '../editor/codemirror/tools';
 
@@ -20,13 +21,13 @@ export default class WidgetsManager {
 
         let from = { line:0, ch:0 };
         let to = {
-            line: TangramPlay.editor.getDoc().size - 1,
-            ch: TangramPlay.editor.getLine(TangramPlay.editor.getDoc().size - 1).length
+            line: editor.getDoc().size - 1,
+            ch: editor.getLine(editor.getDoc().size - 1).length
         };
         this.createRange(from, to);
 
         // If something change only update that
-        TangramPlay.editor.on('changes', (cm, changesObjs) => {
+        editor.on('changes', (cm, changesObjs) => {
             for (let obj of changesObjs) {
                 this.change(obj);
             }
@@ -35,8 +36,8 @@ export default class WidgetsManager {
         // Keep track of possible NOT-PARSED lines
         // and in every codemirror "render update" check if we are approaching a
         // non-parsed area and for it to update by cleaning and creating
-        TangramPlay.editor.on('scroll', (cm) => {
-            let horizon = TangramPlay.editor.getViewport().to - 1;
+        editor.on('scroll', (cm) => {
+            let horizon = editor.getViewport().to - 1;
             if (this.pairedUntilLine < horizon) {
                 let from = {
                     line: this.pairedUntilLine + 1,
@@ -44,7 +45,7 @@ export default class WidgetsManager {
                 };
                 let to = {
                     line: horizon,
-                    ch: TangramPlay.editor.getLine(horizon).length
+                    ch: editor.getLine(horizon).length
                 };
                 this.clearRange(from, to);
                 this.createRange(from, to);
@@ -70,7 +71,7 @@ export default class WidgetsManager {
             to.line = changeObj.from.line + changeObj.text.length - 1;
         }
 
-        to.ch = TangramPlay.editor.getLine(to.line) ? TangramPlay.editor.getLine(to.line).length : 0;
+        to.ch = editor.getLine(to.line) ? editor.getLine(to.line).length : 0;
 
         // If is a new line move the range FROM the begining of the line
         if (changeObj.text.length === 2 &&
@@ -92,11 +93,11 @@ export default class WidgetsManager {
             // If the FROM/TO range is to narrow search using nodes
             for (let node of nodes) {
                 // Find and concatenate bookmarks between FROM/TO range
-                bookmarks = bookmarks.concat(TangramPlay.editor.getDoc().findMarksAt(node.range.to));
+                bookmarks = bookmarks.concat(editor.getDoc().findMarksAt(node.range.to));
             }
         }
         else {
-            bookmarks = TangramPlay.editor.getDoc().findMarksAt(to);
+            bookmarks = editor.getDoc().findMarksAt(to);
         }
 
         // If there is only one node and the change happen on the value
@@ -132,7 +133,7 @@ export default class WidgetsManager {
     }
 
     clearNodes (nodes) {
-        let doc = TangramPlay.editor.getDoc();
+        let doc = editor.getDoc();
         for (let node of nodes) {
             // Find bookmarks between FROM and TO
             let from = node.range.from.line;
@@ -161,7 +162,7 @@ export default class WidgetsManager {
         let newWidgets = [];
         for (let node of nodes) {
             let val = node.value;
-            if (val === '|' || isStrEmpty(val) || isStrEmpty(TangramPlay.editor.getLine(node.range.from.line))) {
+            if (val === '|' || isStrEmpty(val) || isStrEmpty(editor.getLine(node.range.from.line))) {
                 continue;
             }
 


### PR DESCRIPTION
As we're getting better at structuring this as an ES2015 application, we're unwinding from an earlier decision that expected the `TangramPlay` class to hold all of Tangram Play's functionality inside of it. In this PR, the `editor` module initiates itself when Tangram Play is run, and exports an instance of CodeMirror. This allows all other modules who needs access to the editor to be able to import the `editor` module directly, rather than look for it as `TangramPlay.editor`.

cc @irealva @patriciogonzalezvivo 