### PR TITLE
Provide a hanging indent on line wrapping

### DIFF
--- a/src/css/_widgets.css
+++ b/src/css/_widgets.css
@@ -1,5 +1,11 @@
 /* EDITOR WIDGETS */
 
+.CodeMirror-widget {
+    /* Resets this property for wrapped lines. The hanging indent adds
+       its own text-indent and we do not want widgets to inherit it. */
+    text-indent: initial;
+}
+
 .widget {
     display: inline-block;
     position: relative;

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -119,5 +119,23 @@ function initCodeMirror (el) {
         return getLineInd(this, nLine);
     };
 
+    // Better line wrapping. Wrapped lines are based on the indentation
+    // of the current line. See this demo:
+    //      https://codemirror.net/demo/indentwrap.html
+    // Modified slightly to provide an additional hanging indent that is based
+    // off of the document's tabSize setting. This mimics how wrapping behaves
+    // in Sublime Text.
+    const charWidth = cm.defaultCharWidth();
+    const basePadding = 4; // Magic number: it is CodeMirror's default value.
+    cm.on('renderLine', function (cm, line, el) {
+        const tabSize = cm.getOption('tabSize');
+        const columns = CodeMirror.countColumn(line.text, null, tabSize);
+        const offset = (columns + tabSize) * charWidth;
+
+        el.style.textIndent = '-' + offset + 'px';
+        el.style.paddingLeft = (basePadding + offset) + 'px';
+    });
+    cm.refresh();
+
     return cm;
 }


### PR DESCRIPTION
Tangram Play currently wraps lines by default. Line wrapping does not take into account indentation, so for heavily nested code, edges are extremely ragged, like so:

![screenshot 2016-06-10 15 14 20](https://cloud.githubusercontent.com/assets/2553268/15976190/2ccc5a12-2f1f-11e6-88c4-68916707b63a.png)

This can be quite annoying, but then I found this: https://codemirror.net/demo/indentwrap.html

This solution makes indentation line up along the same left edge, but I think that can be just as confusing because it is less clear where the next line begins. We can take a cue from Sublime Text's implementation of line wrapping, which will look at the document's tab spacing and then provide an additional level of indentation for wrapped lines:

![screenshot 2016-06-10 15 15 55](https://cloud.githubusercontent.com/assets/2553268/15976260/9048cee0-2f1f-11e6-8426-6699db7a73aa.png)

That shouldn't be that hard to implement. And so here it is!

![screenshot 2016-06-10 15 15 24](https://cloud.githubusercontent.com/assets/2553268/15976268/9aa18724-2f1f-11e6-8036-75259c3e99cd.png)
