### PR TITLE
Refactor YAML-Tangram state. Add smarter YAML indentation.

### DIFF
--- a/src/js/editor/codemirror/yaml-tangram.js
+++ b/src/js/editor/codemirror/yaml-tangram.js
@@ -367,16 +367,19 @@ export function parseYamlString (string, origState, tabSize) {
     return state;
 }
 
-//  YAML-TANGRAM
-//  ===============================================================================
+// YAML-TANGRAM
+// =============================================================================
+
+// Extend YAML with line comment character (not provided by CodeMirror).
+CodeMirror.extendMode('yaml', {
+    lineComment: '#'
+});
+
 CodeMirror.defineMode('yaml-tangram', function (config, parserConfig) {
     // Import multiple modes used by Tangram YAML.
     const yamlMode = CodeMirror.getMode(config, 'yaml');
     const glslMode = CodeMirror.getMode(config, 'glsl');
     const jsMode = CodeMirror.getMode(config, 'javascript');
-
-    // Specify YAML line comment character (not provided by CodeMirror).
-    yamlMode.lineComment = '#';
 
     function yaml (stream, state) {
         const address = getKeyAddressFromState(state.yamlState);

--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -127,13 +127,13 @@ export function highlightBlock (node) {
 
     // Scroll the top of the block into view. Do this first so that
     // CodeMirror will parse the lines in this viewport. This is necessary
-    // for the `stateAfter.yamlState.keyLevel` to be available.
+    // for the `stateAfter.keyLevel` to be available.
     jumpToLine(editor, node.range.from.line);
 
     // Determine the range to highlight from.
     const blockLine = node.range.from.line;
     // This can still sometimes fail, for unknown reasons.
-    const blockLevel = doc.getLineHandle(blockLine).stateAfter.yamlState.keyLevel;
+    const blockLevel = doc.getLineHandle(blockLine).stateAfter.keyLevel;
     let toLine = blockLine;
     let thisLevel = blockLevel;
     do {
@@ -141,7 +141,7 @@ export function highlightBlock (node) {
         if (nextLineHandle !== undefined && !isEmptyString(nextLineHandle.text)) {
             // The nextLineHandle might not have a stateAfter, so wrap in try {}
             try {
-                thisLevel = nextLineHandle.stateAfter.yamlState.keyLevel;
+                thisLevel = nextLineHandle.stateAfter.keyLevel;
             }
             catch (err) {
                 break;

--- a/src/js/editor/suggest.js
+++ b/src/js/editor/suggest.js
@@ -34,8 +34,8 @@ export default class SuggestManager {
 
             let line = editor.getCursor().line;
             let stateAfter = editor.getLineHandle(line).stateAfter;
-            if (stateAfter && stateAfter.localMode && stateAfter.localMode.helperType) {
-                let helperType = stateAfter.localMode.helperType;
+            if (stateAfter && stateAfter.innerMode && stateAfter.innerMode.helperType) {
+                let helperType = stateAfter.innerMode.helperType;
                 if (helperType === 'glsl' || helperType === 'javascript') {
                     bOpen = false;
                 }

--- a/src/js/glsl/helpers.js
+++ b/src/js/glsl/helpers.js
@@ -28,7 +28,7 @@ export default class Helpers {
             // Exit early if the cursor is not at a token
             let token = editor.getTokenAt(cursor);
 
-            if (token.state.localMode === null || token.state.localMode.helperType !== 'glsl') {
+            if (token.state.innerMode === null || token.state.innerMode.helperType !== 'glsl') {
                 return;
             }
 

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -409,7 +409,7 @@ class TangramPlay {
         for (let line = 0, size = editor.getDoc().size; line < size; line++) {
             const lineHandle = editor.getLineHandle(line);
 
-            if (!lineHandle.stateAfter || !lineHandle.stateAfter.yamlState) {
+            if (!lineHandle.stateAfter) {
                 // If the line is NOT parsed.
                 // ======================================================
                 //
@@ -440,7 +440,7 @@ class TangramPlay {
             else {
                 // it the line HAVE BEEN parsed (use the stateAfter)
                 // ======================================================
-                lastState = lineHandle.stateAfter.yamlState;
+                lastState = lineHandle.stateAfter;
                 let keys = this.getNodesOnLine(line);
                 for (let key of keys) {
                     if (key.address === address) {

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -422,7 +422,7 @@ class TangramPlay {
                 state.line = line;
 
                 // Parse the current state
-                parseYamlString(lineHandle.text, state, 4);
+                state = parseYamlString(lineHandle.text, state, 4);
 
                 // Iterate through keys in this line
                 for (let key of state.nodes) {

--- a/src/js/widgets/widget.js
+++ b/src/js/widgets/widget.js
@@ -41,10 +41,9 @@ export default class Widget {
             this.bookmark.lines.length === 1 &&
             this.bookmark.lines[0] &&
             this.bookmark.lines[0].stateAfter &&
-            this.bookmark.lines[0].stateAfter.yamlState &&
-            this.bookmark.lines[0].stateAfter.yamlState.nodes &&
-            this.bookmark.lines[0].stateAfter.yamlState.nodes.length > 0) {
-            for (let node of this.bookmark.lines[0].stateAfter.yamlState.nodes) {
+            this.bookmark.lines[0].stateAfter.nodes &&
+            this.bookmark.lines[0].stateAfter.nodes.length > 0) {
+            for (let node of this.bookmark.lines[0].stateAfter.nodes) {
                 if (this.node.address === node.address) {
                     this.node = node;
                     break;


### PR DESCRIPTION
So, what's going on here?

**tl;dr** The goal was to make some of the code behind the YAML-Tangram parser easier to reason about.

The first objective is to treat the `yaml-tangram` mode in CodeMirror as an extension of the stock `yaml` mode. Previously in Tangram Play, we moved stock YAML state from `state` to `state.yamlState`, but then various extensions to the state were stored in either level: e.g. `keyStack` is `state.keyStack` but nodes were stored at `state.yamlState.nodes`.  To simplify things, I removed `yamlState` completely, moving all state information back onto the `state` root object. This allowed simplification of some logic, especially for copying state, and put all the properties in one place instead of nesting them at arbitrary levels, so mapping stock `yaml` mode behavior to `yaml-tangram` is much easier to reason about.

Furthermore this begins to clarify that `yaml-tangram` is not just some über-mode consisting of three separate but equal modes (YAML, JavaScript, GLSL) -- but rather, at its root, Tangram YAML _is_ YAML syntax, that will occasionally need to delegate to JavaScript and GLSL (or C-like, in CodeMirror parlance) when certain blocks contain that kind of code. The model we should be keeping in mind is not that YAML hands control to JavaScript which hands control back to YAML which hands control to GLSL: improperly formatted comments and autocomplete dropdowns behaving badly are side effects of that model. Although there is still more work to be done here, the eventual model I would like to explore is that YAML is always in control but delegates actions to sub-modes on a per-line basis.

One major under-the-hood change in this direction is that the `yaml-tangram` `token()` method is now solely responsible for incrementing the `state.line` value. (Previously, each of the three language modes were doing this individually.)

Sub-modes are now called `innerState` and `innerMode`, keeping with CodeMirror parlance, rather than `localState` and `localMode`. `null` values for each continue to mean that there is no active sub-mode.

----

One final improvement that made its way here is smarter YAML indentation. The implementation follows what was proposed in #167, which is intended to be ignorant about the particulars of Tangram syntax, but instead infers what to do based on context. This strategy is copied here:

In YAML mode, if you insert a new line and the previous line ends with no value or a pipe `|` character, assume additional indentation. Like so:

```yaml
# No value immediately after the key
this:
    # indent starts here
```

```yaml
# Value is a pipe character
multiline: |
    # indent starts here
```

If the new line follows a line with a value, then we assume that the new line is on the same indentation level as the previous value.

```yaml
thing: true
# indent starts here
```

This allows us to predict indentation without needing to know Tangram syntax or rely on regexes.

----

Thoughts, @irealva @patriciogonzalezvivo ?
