### PR TITLE
Global introspection mode.

### DIFF
--- a/src/css/_map-inspection.css
+++ b/src/css/_map-inspection.css
@@ -219,3 +219,9 @@
     transition: opacity 120ms ease-out, transform 100ms ease-out;
     transform: translateY(-20px) translateZ(100px);
 }
+
+/* Crosshair cursor is active when global introspection mode is on.
+   Only apply it when the user is not dragging the map. */
+body:not(.leaflet-dragging) .map-crosshair {
+    cursor: crosshair;
+}

--- a/src/css/_map-inspection.css
+++ b/src/css/_map-inspection.css
@@ -4,7 +4,7 @@
     background-color: rgba(0, 0, 0, 0.85);
     font-family: var(--font-family);
     font-weight: 200;
-    font-size: 0.75rem; /* TODO: create & associate with global font scale */
+    font-size: 1.2rem; /* TODO: create & associate with global font scale */
     color: var(--ui-component-text-color);
     z-index: var(--z04-map-inspection);
     min-width: 85px;

--- a/src/css/_map-inspection.css
+++ b/src/css/_map-inspection.css
@@ -4,7 +4,7 @@
     background-color: rgba(0, 0, 0, 0.85);
     font-family: var(--font-family);
     font-weight: 200;
-    font-size: 1.2rem; /* TODO: create & associate with global font scale */
+    font-size: 0.75rem; /* TODO: create & associate with global font scale */
     color: var(--ui-component-text-color);
     z-index: var(--z04-map-inspection);
     min-width: 85px;

--- a/src/css/_map-inspection.css
+++ b/src/css/_map-inspection.css
@@ -80,6 +80,7 @@
     text-transform: uppercase;
     color: var(--ui-subtext-color);
     vertical-align: middle;
+    width: 60px;
 }
 
 .map-inspection-properties-table-wrapper {

--- a/src/css/_map-inspection.css
+++ b/src/css/_map-inspection.css
@@ -67,12 +67,19 @@
     background-color: var(--ui-base-color);
     user-select: none;
     cursor: default;
+    line-height: 1.4;
 }
 
-.map-inspection-properties {
-    box-sizing: border-box;
-    line-height: 1.4;
+.map-inspection-source {
     margin-top: 0.25em;
+}
+
+.map-inspection-source-item-label {
+    font-size: 0.75em;
+    font-weight: 400;
+    text-transform: uppercase;
+    color: var(--ui-subtext-color);
+    vertical-align: middle;
 }
 
 .map-inspection-properties-table-wrapper {
@@ -80,6 +87,7 @@
     max-height: 88px; /* should be exactly four rows */
     overflow-y: auto;
     overflow-x: hidden;
+    line-height: 1.4;
 
     &::-webkit-scrollbar {
         width: 8px;

--- a/src/css/_menu-bar.react.css
+++ b/src/css/_menu-bar.react.css
@@ -66,6 +66,11 @@ nav {
 
 .menu-bar li.active a {
     color: var(--ui-highlight-color);
+    font-weight: 600;
+}
+
+.menu-bar li.active i {
+    font-weight: 900;
 }
 
 .menu-bar .dropdown-menu li {

--- a/src/css/_menu-bar.react.css
+++ b/src/css/_menu-bar.react.css
@@ -64,6 +64,10 @@ nav {
     }
 }
 
+.menu-bar li.active a {
+    color: var(--ui-highlight-color);
+}
+
 .menu-bar .dropdown-menu li {
     border-top: 1px solid var(--ui-active-color);
 

--- a/src/js/components/menu-bar.react.js
+++ b/src/js/components/menu-bar.react.js
@@ -51,10 +51,6 @@ const _clickSaveCamera = function () {
     takeScreenshot();
 };
 
-const _clickFullscreen = function () {
-    toggleFullscreen();
-};
-
 const _clickAbout = function () {
     aboutModal.show();
 };
@@ -70,6 +66,7 @@ export default class MenuBar extends React.Component {
         super(props);
         this.state = {
             inspectActive: false, // Represents whether inspect mode is on / off
+            fullscreenActive: false
         };
     }
 
@@ -114,18 +111,18 @@ export default class MenuBar extends React.Component {
                                 <MenuItem onClick={_clickSaveCamera}><Icon type={'bt-camera'} />Take a screenshot</MenuItem>
                             </NavDropdown>
                         </OverlayTrigger>
-
-                        {/* Introspection button */}
-                        <OverlayTrigger rootClose placement='bottom' overlay={<Tooltip id='tooltip'>{'Toggle inspect mode'}</Tooltip>}>
-                            <NavItem eventKey={'new'} onClick={this._clickInspect.bind(this)} href='#' active={this.state.inspectActive}><Icon type={'bt-wrench'} />Inspect</NavItem>
-                        </OverlayTrigger>
                     </Nav>
 
                     {/* Right menu section */}
                     <Nav pullRight>
+                        {/* Introspection button */}
+                        <OverlayTrigger rootClose placement='bottom' overlay={<Tooltip id='tooltip'>{'Toggle inspect mode'}</Tooltip>}>
+                            <NavItem eventKey={'new'} onClick={this._clickInspect.bind(this)} href='#' active={this.state.inspectActive}><Icon type={'bt-wrench'} />Inspect</NavItem>
+                        </OverlayTrigger>
+
                         {/* Fullscreen button */}
                         <OverlayTrigger rootClose placement='bottom' overlay={<Tooltip id='tooltip'>{'View fullscreen'}</Tooltip>}>
-                            <NavItem eventKey={'new'} onClick={_clickFullscreen} href='#'><Icon type={'bt-maximize'} />Fullscreen</NavItem>
+                            <NavItem eventKey={'new'} onClick={this._clickFullscreen.bind(this)} href='#' active={this.state.fullscreenActive}><Icon type={'bt-maximize'} />Fullscreen</NavItem>
                         </OverlayTrigger>
 
                         {/* Help dropdown */}
@@ -140,6 +137,11 @@ export default class MenuBar extends React.Component {
                 </Navbar.Collapse>
             </Navbar>
         );
+    }
+
+    _clickFullscreen () {
+        this.setState({ fullscreenActive: !this.state.fullscreenActive });
+        toggleFullscreen();
     }
 
     _clickInspect () {

--- a/src/js/components/menu-bar.react.js
+++ b/src/js/components/menu-bar.react.js
@@ -50,10 +50,6 @@ const _clickSaveCamera = function () {
     takeScreenshot();
 };
 
-const _clickInspect = function () {
-    setGlobalIntrospection(true);
-};
-
 const _clickFullscreen = function () {
     toggleFullscreen();
 };
@@ -69,6 +65,13 @@ const feedbackLink = 'https://github.com/tangrams/tangram-play/issues/';
  * Represents the navbar for the application
  */
 export default class MenuBar extends React.Component {
+    constructor (props) {
+        super(props);
+        this.state = {
+            inspectActive: false, // Represents whether inspect mode is on / off
+        };
+    }
+
     /**
      * Official React lifecycle method
      * Called every time state or props are changed
@@ -113,7 +116,7 @@ export default class MenuBar extends React.Component {
 
                         {/* Introspection button */}
                         <OverlayTrigger rootClose placement='bottom' overlay={<Tooltip id='tooltip'>{'Toggle inspect mode'}</Tooltip>}>
-                            <NavItem eventKey={'new'} onClick={_clickInspect} href='#'><Icon type={'bt-wrench'} />Inspect</NavItem>
+                            <NavItem eventKey={'new'} onClick={this._clickInspect.bind(this)} href='#' active={this.state.inspectActive}><Icon type={'bt-wrench'} />Inspect</NavItem>
                         </OverlayTrigger>
                     </Nav>
 
@@ -136,5 +139,17 @@ export default class MenuBar extends React.Component {
                 </Navbar.Collapse>
             </Navbar>
         );
+    }
+
+    _clickInspect () {
+        const isInspectActive = this.state.inspectActive;
+        if (isInspectActive) {
+            this.setState({ inspectActive: false });
+            setGlobalIntrospection(false);
+        }
+        else {
+            this.setState({ inspectActive: true });
+            setGlobalIntrospection(true);
+        }
     }
 }

--- a/src/js/components/menu-bar.react.js
+++ b/src/js/components/menu-bar.react.js
@@ -16,7 +16,7 @@ import { openGistModal } from '../modals/modal.open-gist';
 import { saveGistModal } from '../modals/modal.save-gist';
 import { aboutModal } from '../modals/modal.about';
 import { toggleFullscreen } from '../ui/fullscreen';
-import { takeScreenshot } from '../map/map';
+import { takeScreenshot, setGlobalIntrospection } from '../map/map';
 
 const _clickNew = function () {
     EditorIO.new();
@@ -48,6 +48,10 @@ const _clickSaveGist = function () {
 
 const _clickSaveCamera = function () {
     takeScreenshot();
+};
+
+const _clickInspect = function () {
+    setGlobalIntrospection(true);
 };
 
 const _clickFullscreen = function () {
@@ -105,6 +109,11 @@ export default class MenuBar extends React.Component {
                                 <MenuItem onClick={_clickSaveGist}><Icon type={'bt-code'} />Save to Gist</MenuItem>
                                 <MenuItem onClick={_clickSaveCamera}><Icon type={'bt-camera'} />Take a screenshot</MenuItem>
                             </NavDropdown>
+                        </OverlayTrigger>
+
+                        {/* Introspection button */}
+                        <OverlayTrigger rootClose placement='bottom' overlay={<Tooltip id='tooltip'>{'Toggle inspect mode'}</Tooltip>}>
+                            <NavItem eventKey={'new'} onClick={_clickInspect} href='#'><Icon type={'bt-wrench'} />Inspect</NavItem>
                         </OverlayTrigger>
                     </Nav>
 

--- a/src/js/components/menu-bar.react.js
+++ b/src/js/components/menu-bar.react.js
@@ -117,7 +117,7 @@ export default class MenuBar extends React.Component {
                     <Nav pullRight>
                         {/* Introspection button */}
                         <OverlayTrigger rootClose placement='bottom' overlay={<Tooltip id='tooltip'>{'Toggle inspect mode'}</Tooltip>}>
-                            <NavItem eventKey={'new'} onClick={this._clickInspect.bind(this)} href='#' active={this.state.inspectActive}><Icon type={'bt-wrench'} />Inspect</NavItem>
+                            <NavItem eventKey={'new'} onClick={this._clickInspect.bind(this)} href='#' active={this.state.inspectActive}><Icon type={'bt-magic'} />Inspect</NavItem>
                         </OverlayTrigger>
 
                         {/* Fullscreen button */}

--- a/src/js/components/menu-bar.react.js
+++ b/src/js/components/menu-bar.react.js
@@ -16,7 +16,8 @@ import { openGistModal } from '../modals/modal.open-gist';
 import { saveGistModal } from '../modals/modal.save-gist';
 import { aboutModal } from '../modals/modal.about';
 import { toggleFullscreen } from '../ui/fullscreen';
-import { takeScreenshot, setGlobalIntrospection } from '../map/map';
+import { takeScreenshot } from '../map/map';
+import { setGlobalIntrospection } from '../map/inspection';
 
 const _clickNew = function () {
     EditorIO.new();

--- a/src/js/map/inspection.js
+++ b/src/js/map/inspection.js
@@ -30,6 +30,10 @@ class TangramInspectionPopup {
         headerEl.appendChild(kindEl);
         headerEl.appendChild(nameEl);
 
+        let sourceEl = this._sourceEl = document.createElement('div');
+        sourceEl.className = 'map-inspection-source';
+        sourceEl.style.display = 'none';
+
         let propertiesEl = this._propertiesEl = document.createElement('div');
         propertiesEl.className = 'map-inspection-properties';
         propertiesEl.style.display = 'none';
@@ -45,6 +49,7 @@ class TangramInspectionPopup {
         // Listeners for this will be added later, during popup creation
 
         el.appendChild(headerEl);
+        el.appendChild(sourceEl);
         el.appendChild(propertiesEl);
         el.appendChild(layersEl);
         el.appendChild(closeEl);
@@ -145,6 +150,58 @@ class TangramInspectionPopup {
     get name () {
         let text = this._nameEl.textContent;
         return text !== EMPTY_SELECTION_NAME_LABEL ? text : null;
+    }
+
+    showSource (name, layer) {
+        emptyDOMElement(this._sourceEl);
+
+        // Add section label
+        const labelEl = document.createElement('div');
+        labelEl.className = 'map-inspection-label';
+        labelEl.textContent = 'Data source';
+
+        this._sourceEl.appendChild(labelEl);
+
+        // Create table element
+        const tableWrapperEl = document.createElement('div');
+        const tableEl = document.createElement('table');
+        const tbodyEl = document.createElement('tbody');
+
+        tableWrapperEl.className = 'map-inspection-properties-table-wrapper';
+        tableEl.className = 'map-inspection-properties-table';
+        tableEl.appendChild(tbodyEl);
+
+        // Alphabetize key-value pairs
+        let properties = [
+            ['Name', name],
+            ['Layer', layer]
+        ];
+
+        for (let x in properties) {
+            const key = properties[x][0];
+            const value = properties[x][1];
+
+            const tr = document.createElement('tr');
+            const tdKey = document.createElement('td');
+            const tdValue = document.createElement('td');
+            tdKey.className = 'map-inspection-source-item-label';
+            tdKey.textContent = key;
+            tdValue.textContent = value;
+            tr.appendChild(tdKey);
+            tr.appendChild(tdValue);
+
+            tbodyEl.appendChild(tr);
+        }
+
+        tableWrapperEl.appendChild(tableEl);
+        this._sourceEl.appendChild(tableWrapperEl);
+
+        this._sourceEl.style.display = 'block';
+    }
+
+    hideSource () {
+        emptyDOMElement(this._sourceEl);
+        this._sourceEl.style.display = 'none';
     }
 
     showProperties (properties) {
@@ -406,6 +463,7 @@ export function handleInspectionClickEvent (selection) {
 
     inspectPopup.resetPosition();
     inspectPopup.setLabel(selection.feature.properties);
+    inspectPopup.showSource(selection.feature.source_name, selection.feature.source_layer);
     inspectPopup.showProperties(selection.feature.properties);
     inspectPopup.showLayers(selection.feature.layers);
     inspectPopup.showPopup(selection.leaflet_event);

--- a/src/js/map/inspection.js
+++ b/src/js/map/inspection.js
@@ -479,4 +479,12 @@ export function handleInspectionClickEvent (selection) {
 export function setGlobalIntrospection (boolean) {
     tangramLayer.scene.setIntrospection(boolean);
     globalIntrospectionState = boolean;
+
+    // Turn mouse cursor into a crosshair when on the map
+    if (boolean === true) {
+        map.getContainer().classList.add('map-crosshair');
+    }
+    else {
+        map.getContainer().classList.remove('map-crosshair');
+    }
 }

--- a/src/js/map/inspection.js
+++ b/src/js/map/inspection.js
@@ -190,6 +190,17 @@ class TangramInspectionPopup {
             tr.appendChild(tdKey);
             tr.appendChild(tdValue);
 
+            // Clicking on the source name should scroll to its position in the editor.
+            // `node` will be undefined if it is not found in the current scene
+            if (value === name) {
+                const node = TangramPlay.getNodesForAddress('sources:' + name);
+                if (node) {
+                    tr.addEventListener('click', event => {
+                        highlightBlock(node);
+                    });
+                }
+            }
+
             tbodyEl.appendChild(tr);
         }
 
@@ -252,8 +263,6 @@ class TangramInspectionPopup {
         this._propertiesEl.style.display = 'block';
         // Resets scroll position (we don't want it to remember scroll position of the previous set of properties)
         this._propertiesEl.scrollTop = 0;
-
-        this._closeEl.style.display = 'block';
     }
 
     hideProperties () {
@@ -372,6 +381,7 @@ class TangramInspectionPopup {
         this._closeEl.addEventListener('click', event => {
             map.closePopup(popup);
         });
+        this._closeEl.style.display = 'block';
 
         // Provide an animation in. By itself, the translateZ doesn't mean anything.
         // It's just a "transition from" point. Leaflet adds an animation class

--- a/src/js/map/inspection.js
+++ b/src/js/map/inspection.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import L from 'leaflet';
-import { map } from './map';
+import { map, tangramLayer } from './map';
 import { emptyDOMElement } from '../tools/helpers';
 import TangramPlay from '../tangram-play';
 import { highlightBlock, unhighlightAll } from '../editor/highlight';
@@ -10,6 +10,7 @@ const EMPTY_SELECTION_NAME_LABEL = '(unnamed)';
 
 let isPopupOpen = false;
 let currentPopupX, currentPopupY;
+let globalIntrospectionState = false;
 
 class TangramInspectionPopup {
     constructor () {
@@ -359,6 +360,11 @@ const hoverPopup = new TangramInspectionPopup();
 hoverPopup.el.className += ' map-inspection-hover';
 
 export function handleInspectionHoverEvent (selection) {
+    // Experiment: only show popups when global introspection is on.
+    if (globalIntrospectionState === false) {
+        return;
+    }
+
     if (isPopupOpen === true) {
         return;
     }
@@ -376,6 +382,11 @@ export function handleInspectionHoverEvent (selection) {
 }
 
 export function handleInspectionClickEvent (selection) {
+    // Experiment: only show popups when global introspection is on.
+    if (globalIntrospectionState === false) {
+        return;
+    }
+
     // Don't display a new popup if the click does not return a feature
     // (e.g. interactive: false)
     if (!selection.feature) {
@@ -398,4 +409,16 @@ export function handleInspectionClickEvent (selection) {
     inspectPopup.showProperties(selection.feature.properties);
     inspectPopup.showLayers(selection.feature.layers);
     inspectPopup.showPopup(selection.leaflet_event);
+}
+
+/**
+ * Turns on global introspection mode for Tangram.
+ *
+ * @public
+ * @param {Boolean} - when `true`, the interactive flag is turned on for all
+ *          geometry. when `false`, interactivity defers to scene file rules.
+ */
+export function setGlobalIntrospection (boolean) {
+    tangramLayer.scene.setIntrospection(boolean);
+    globalIntrospectionState = boolean;
 }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -178,6 +178,17 @@ function getMapStartLocation () {
     return startLocation;
 }
 
+/**
+ * Turns on global introspection mode for Tangram.
+ *
+ * @public
+ * @param {Boolean} - when `true`, the interactive flag is turned on for all
+ *          geometry. when `false`, interactivity defers to scene file rules.
+ */
+export function setGlobalIntrospection (boolean) {
+    tangramLayer.scene.setIntrospection(boolean);
+}
+
 /* New section to handle React components */
 
 // Need to setup dispatch services to let the React component MapPanel know when map has changed

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -178,17 +178,6 @@ function getMapStartLocation () {
     return startLocation;
 }
 
-/**
- * Turns on global introspection mode for Tangram.
- *
- * @public
- * @param {Boolean} - when `true`, the interactive flag is turned on for all
- *          geometry. when `false`, interactivity defers to scene file rules.
- */
-export function setGlobalIntrospection (boolean) {
-    tangramLayer.scene.setIntrospection(boolean);
-}
-
 /* New section to handle React components */
 
 // Need to setup dispatch services to let the React component MapPanel know when map has changed


### PR DESCRIPTION
Now that the menu bar is Reactified, it was pretty easy to wire up a button to some functionality that turns on global introspection mode.

I'd gotten some feedback from @hanbyul-here earlier where she put in `interactive: true` on a layer in the Tangram scene to turn on the inspection popup, thinking that it was a built-in piece of Tangram functionality and that’s how you would activate it, but was confused when it was no longer there when the scene was displayed on a map page. So, it doesn't seem clear that `interactive: true` is something Tangram Play hooks into in order to do introspection, but in order to have any functionality outside of Play, the developer is expected to handle that herself. As an experiment, this PR also disables inspection popups for individual layers, so that the inspection mode is tied directly to Tangram Play UI rather than lines inside of the scene file. Let's give this a try and see if this makes sense.

I'm also not entirely happy with the icon selection for the Inspect button, but any decision regarding icons is dependent on the path we take to address #46. This PR also unifies Inspect and Fullscreen modes' "active" state by turning its font weight bold, but I'm open to alternative solutions for this, since bold text might not fit for the "look and feel" of Play.

cc @bcamper @migurski 