### PR TITLE
Refactor widget markers to make their existence more reliable and performant.

### DIFF
--- a/src/js/editor/codemirror/widgets.js
+++ b/src/js/editor/codemirror/widgets.js
@@ -1,25 +1,25 @@
 import _ from 'lodash';
 import TANGRAM_API from '../../tangram-api.json';
-import WidgetConstructor from '../../widgets/widget-type';
+import WidgetMarkConstructor from '../../widgets/widget-type';
 import { isEmptyString } from '../../tools/helpers';
 
 // Only certain types of values in Tangram syntax will have widgets, so
 // filter out all other ones.
-const listOfWidgetConstructors = _.filter(TANGRAM_API.values, function (item) {
+const listOfWidgetMarkConstructors = _.filter(TANGRAM_API.values, function (item) {
     return item.type === 'color' || item.type === 'vector' || item.type === 'boolean' || item.type === 'string';
 });
 
 // Create a set of ready-to-go widget objects.
-const allWidgetConstructors = listOfWidgetConstructors.map(function (item) {
-    // new WidgetConstructor() is passed an object from TANGRAM_API.
-    return new WidgetConstructor(item);
+const allWidgetMarkConstructors = listOfWidgetMarkConstructors.map(function (item) {
+    // new WidgetMarkConstructor() is passed an object from TANGRAM_API.
+    return new WidgetMarkConstructor(item);
 });
 
 /**
  * Given a state from YAML-Tangram parser, adds matching widget constructors
  * to each node.
  */
-export function attachWidgetConstructorsToDocumentState (state) {
+export function attachWidgetMarkConstructorsToDocumentState (state) {
     const nodes = state.nodes || [];
     for (let node of nodes) {
         const value = node.value;
@@ -28,9 +28,9 @@ export function attachWidgetConstructorsToDocumentState (state) {
         }
 
         // Check for widgets to add
-        for (let widgetConstructor of allWidgetConstructors) {
-            if (widgetConstructor.match(node)) {
-                node.widgetConstructor = widgetConstructor;
+        for (let widgetMarkConstructor of allWidgetMarkConstructors) {
+            if (widgetMarkConstructor.match(node)) {
+                node.widgetMarkConstructor = widgetMarkConstructor;
                 break;
             }
         }

--- a/src/js/editor/codemirror/widgets.js
+++ b/src/js/editor/codemirror/widgets.js
@@ -1,33 +1,36 @@
 import _ from 'lodash';
 import TANGRAM_API from '../../tangram-api.json';
-import WidgetType from '../../widgets/widget-type';
-
+import WidgetConstructor from '../../widgets/widget-type';
 import { isEmptyString } from '../../tools/helpers';
 
 // Only certain types of values in Tangram syntax will have widgets, so
 // filter out all other ones.
-const widgetToMakeWidgetsFor = _.filter(TANGRAM_API.values, function (item) {
+const listOfWidgetConstructors = _.filter(TANGRAM_API.values, function (item) {
     return item.type === 'color' || item.type === 'vector' || item.type === 'boolean' || item.type === 'string';
 });
 
 // Create a set of ready-to-go widget objects.
-const allWidgetTypes = widgetToMakeWidgetsFor.map(function (item) {
-    // new WidgetType() is passed an object from TANGRAM_API.
-    return new WidgetType(item);
+const allWidgetConstructors = listOfWidgetConstructors.map(function (item) {
+    // new WidgetConstructor() is passed an object from TANGRAM_API.
+    return new WidgetConstructor(item);
 });
 
-export function addWidgets (state) {
+/**
+ * Given a state from YAML-Tangram parser, adds matching widget constructors
+ * to each node.
+ */
+export function attachWidgetConstructorsToDocumentState (state) {
     const nodes = state.nodes || [];
     for (let node of nodes) {
-        let value = node.value;
+        const value = node.value;
         if (value === '|' || isEmptyString(value)) {
             continue;
         }
 
         // Check for widgets to add
-        for (let widgetType of allWidgetTypes) {
-            if (widgetType.match(node)) {
-                node.widget = widgetType;
+        for (let widgetConstructor of allWidgetConstructors) {
+            if (widgetConstructor.match(node)) {
+                node.widgetConstructor = widgetConstructor;
                 break;
             }
         }

--- a/src/js/editor/codemirror/widgets.js
+++ b/src/js/editor/codemirror/widgets.js
@@ -1,0 +1,37 @@
+import _ from 'lodash';
+import TANGRAM_API from '../../tangram-api.json';
+import WidgetType from '../../widgets/widget-type';
+
+import { isEmptyString } from '../../tools/helpers';
+
+// Only certain types of values in Tangram syntax will have widgets, so
+// filter out all other ones.
+const widgetToMakeWidgetsFor = _.filter(TANGRAM_API.values, function (item) {
+    return item.type === 'color' || item.type === 'vector' || item.type === 'boolean' || item.type === 'string';
+});
+
+// Create a set of ready-to-go widget objects.
+const allWidgetTypes = widgetToMakeWidgetsFor.map(function (item) {
+    // new WidgetType() is passed an object from TANGRAM_API.
+    return new WidgetType(item);
+});
+
+export function addWidgets (state) {
+    const nodes = state.nodes || [];
+    for (let node of nodes) {
+        let value = node.value;
+        if (value === '|' || isEmptyString(value)) {
+            continue;
+        }
+
+        // Check for widgets to add
+        for (let widgetType of allWidgetTypes) {
+            if (widgetType.match(node)) {
+                node.widget = widgetType;
+                break;
+            }
+        }
+    }
+
+    return state;
+}

--- a/src/js/editor/codemirror/yaml-tangram.js
+++ b/src/js/editor/codemirror/yaml-tangram.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import CodeMirror from 'codemirror';
 import 'codemirror/mode/yaml/yaml.js';
 import './glsl-tangram';
+import { addWidgets } from './widgets';
 
 import { tangramScene } from '../../map/map';
 
@@ -343,6 +344,9 @@ export function parseYamlString (string, state, tabSize) {
         nodeEntry.address = getAddressFromKeys(state.keyStack);
         state.nodes = [nodeEntry];
     }
+
+    // Adds widgets to nodes, if they have them.
+    state = addWidgets(state);
 
     return state;
 }

--- a/src/js/editor/codemirror/yaml-tangram.js
+++ b/src/js/editor/codemirror/yaml-tangram.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import CodeMirror from 'codemirror';
 import 'codemirror/mode/yaml/yaml.js';
 import './glsl-tangram';
-import { attachWidgetConstructorsToDocumentState } from './widgets';
+import { attachWidgetMarkConstructorsToDocumentState } from './widgets';
 
 import { tangramScene } from '../../map/map';
 
@@ -346,7 +346,7 @@ export function parseYamlString (string, state, tabSize) {
     }
 
     // Adds widgets to nodes, if they have them.
-    state = attachWidgetConstructorsToDocumentState(state);
+    state = attachWidgetMarkConstructorsToDocumentState(state);
 
     return state;
 }

--- a/src/js/editor/editor.js
+++ b/src/js/editor/editor.js
@@ -124,3 +124,39 @@ export function getNodesInRange (from, to) {
     }
     return nodes;
 }
+
+/**
+ * Sets a node's value. If a value is prepended with a YAML anchor, the
+ * anchor is left in place.
+ *
+ * @public
+ * @param {Object} node - An object representing the node whose value changes
+ * @param {string} value - The new value to set to
+ * @param {string} origin - Optional. This should be a string that CodeMirror
+ *          uses to understand where a change is coming from. Use CodeMirror's
+ *          `+` prefix if you want changes to stack in undo history.
+ */
+export function setNodeValue (node, value, origin) {
+    const doc = editor.getDoc();
+
+    // Force a space between the ':' and the value
+    if (node.value === '') {
+        value = ' ' + value;
+    }
+
+    // Calculate beginning character of the value
+    //               key:_[anchor]value
+    //               ^ ^^^^
+    //               | ||||__ + anchor.length
+    //               | |||___ + 1
+    //               | | `--- + 1
+    //  range.from.ch  key.length
+    const fromPos = {
+        line: node.range.from.line,
+        // Magic number: 2 refers to the colon + space between key and value
+        ch: node.range.from.ch + node.key.length + 2 + node.anchor.length
+    };
+    const toPos = node.range.to;
+
+    doc.replaceRange(value, fromPos, toPos, origin);
+}

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -17,8 +17,8 @@ import { editor, getEditorContent, setEditorContent, getNodesOfLine } from './ed
 
 // Addons
 import { showSceneLoadingIndicator, hideSceneLoadingIndicator } from './map/loading';
+import { initWidgetMarks } from './widgets/widgets-manager';
 import ErrorModal from './modals/modal.error';
-import WidgetsManager from './widgets/widgets-manager';
 import SuggestManager from './editor/suggest';
 import ErrorsManager from './editor/errors';
 // import GlslSandbox from './glsl/sandbox';
@@ -85,6 +85,9 @@ class TangramPlay {
                     highlightLines(startLine, endLine, false);
                 }
 
+                // Add widgets marks.
+                initWidgetMarks();
+
                 // Things we do after Tangram is finished initializing
                 tangramLayer.scene.initializing.then(() => {
                     this.trigger('sceneinit');
@@ -123,7 +126,6 @@ class TangramPlay {
 
     //  ADDONS
     initAddons () {
-        this.addons.widgetsManager = new WidgetsManager();
         this.addons.suggestManager = new SuggestManager();
         // this.addons.glslSandbox = new GlslSandbox();
         this.addons.glslHelpers = new GlslHelpers();

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -292,27 +292,6 @@ class TangramPlay {
         editor.on('changes', this._watchEditorForChanges);
     }
 
-    // SET
-    setValue (node, str) {
-        // Force space between the ':' and the value
-        if (node.value === '') {
-            str = ' ' + str;
-        }
-
-        // Calculate begining character of the value
-        //               key:_[anchor]value
-        //               ^ ^^^^
-        //               | ||||__ + anchor.length
-        //               | |||___ + 1
-        //               | | `--- + 1
-        //  range.from.ch  key.lenght
-
-        let from = { line: node.range.from.line,
-                     ch: node.range.from.ch + node.anchor.length + node.key.length + 2 };
-
-        editor.doc.replaceRange(str, from, node.range.to);
-    }
-
     // If editor is updated, send it to the map.
     updateContent () {
         const content = getEditorContent();

--- a/src/js/widgets/color-palette.js
+++ b/src/js/widgets/color-palette.js
@@ -3,6 +3,7 @@ import { editor } from '../editor/editor';
 import ColorPicker from '../pickers/color';
 import { toCSS } from '../tools/common';
 import { jumpToLine } from '../editor/codemirror/tools';
+import { EventEmitter } from '../components/event-emitter';
 
 export default class ColorPalette {
     constructor () {
@@ -11,12 +12,8 @@ export default class ColorPalette {
         this.palette.className = 'colorpalette';
         document.body.appendChild(this.palette);
 
-        TangramPlay.on('widget_marks_created', (args) => {
-            TangramPlay.addons.colorPalette.update(args);
-        });
-
-        // TODO: This might not be triggered anywhere. Update or fix.
-        TangramPlay.on('widget_updated', (args) => {
+        // Receive events when new widget markers are created
+        EventEmitter.subscribe('widget_marks_created', (args) => {
             TangramPlay.addons.colorPalette.update(args);
         });
 

--- a/src/js/widgets/color-palette.js
+++ b/src/js/widgets/color-palette.js
@@ -6,30 +6,30 @@ import { jumpToLine } from '../editor/codemirror/tools';
 
 export default class ColorPalette {
     constructor () {
-        // if (TangramPlay.addons.widgetsManager === undefined) {
-        //     return;
-        // }
-        //
-        // this.colors = {};
-        // this.palette = document.createElement('div');
-        // this.palette.className = 'colorpalette';
-        // document.body.appendChild(this.palette);
-        //
-        // TangramPlay.addons.widgetsManager.on('widgets_created', (args) => {
-        //     TangramPlay.addons.colorPalette.update(args);
-        // });
-        //
-        // TangramPlay.addons.widgetsManager.on('widget_updated', (args) => {
-        //     TangramPlay.addons.colorPalette.update(args);
-        // });
-        //
-        // // If is a new file load all colors by going to the end and comeback
-        // TangramPlay.on('sceneload', (event) => {
-        //     for (let i = 0; i < editor.getDoc().size; i++) {
-        //         jumpToLine(editor, i);
-        //     }
-        //     jumpToLine(editor, 0);
-        // });
+        if (TangramPlay.addons.widgetsManager === undefined) {
+            return;
+        }
+
+        this.colors = {};
+        this.palette = document.createElement('div');
+        this.palette.className = 'colorpalette';
+        document.body.appendChild(this.palette);
+
+        TangramPlay.addons.widgetsManager.on('widgets_created', (args) => {
+            TangramPlay.addons.colorPalette.update(args);
+        });
+
+        TangramPlay.addons.widgetsManager.on('widget_updated', (args) => {
+            TangramPlay.addons.colorPalette.update(args);
+        });
+
+        // If is a new file load all colors by going to the end and comeback
+        TangramPlay.on('sceneload', (event) => {
+            for (let i = 0; i < editor.getDoc().size; i++) {
+                jumpToLine(editor, i);
+            }
+            jumpToLine(editor, 0);
+        });
     }
 
     update (args) {

--- a/src/js/widgets/color-palette.js
+++ b/src/js/widgets/color-palette.js
@@ -6,22 +6,20 @@ import { jumpToLine } from '../editor/codemirror/tools';
 
 export default class ColorPalette {
     constructor () {
-        if (TangramPlay.addons.widgetsManager === undefined) {
-            return;
-        }
-
         this.colors = {};
         this.palette = document.createElement('div');
         this.palette.className = 'colorpalette';
         document.body.appendChild(this.palette);
 
-        TangramPlay.addons.widgetsManager.on('widgets_created', (args) => {
-            TangramPlay.addons.colorPalette.update(args);
-        });
+        // TODO: replace this.
 
-        TangramPlay.addons.widgetsManager.on('widget_updated', (args) => {
-            TangramPlay.addons.colorPalette.update(args);
-        });
+        // TangramPlay.addons.widgetsManager.on('widgets_created', (args) => {
+        //     TangramPlay.addons.colorPalette.update(args);
+        // });
+        //
+        // TangramPlay.addons.widgetsManager.on('widget_updated', (args) => {
+        //     TangramPlay.addons.colorPalette.update(args);
+        // });
 
         // If is a new file load all colors by going to the end and comeback
         TangramPlay.on('sceneload', (event) => {

--- a/src/js/widgets/color-palette.js
+++ b/src/js/widgets/color-palette.js
@@ -6,30 +6,30 @@ import { jumpToLine } from '../editor/codemirror/tools';
 
 export default class ColorPalette {
     constructor () {
-        if (TangramPlay.addons.widgetsManager === undefined) {
-            return;
-        }
-
-        this.colors = {};
-        this.palette = document.createElement('div');
-        this.palette.className = 'colorpalette';
-        document.body.appendChild(this.palette);
-
-        TangramPlay.addons.widgetsManager.on('widgets_created', (args) => {
-            TangramPlay.addons.colorPalette.update(args);
-        });
-
-        TangramPlay.addons.widgetsManager.on('widget_updated', (args) => {
-            TangramPlay.addons.colorPalette.update(args);
-        });
-
-        // If is a new file load all colors by going to the end and comeback
-        TangramPlay.on('sceneload', (event) => {
-            for (let i = 0; i < editor.getDoc().size; i++) {
-                jumpToLine(editor, i);
-            }
-            jumpToLine(editor, 0);
-        });
+        // if (TangramPlay.addons.widgetsManager === undefined) {
+        //     return;
+        // }
+        //
+        // this.colors = {};
+        // this.palette = document.createElement('div');
+        // this.palette.className = 'colorpalette';
+        // document.body.appendChild(this.palette);
+        //
+        // TangramPlay.addons.widgetsManager.on('widgets_created', (args) => {
+        //     TangramPlay.addons.colorPalette.update(args);
+        // });
+        //
+        // TangramPlay.addons.widgetsManager.on('widget_updated', (args) => {
+        //     TangramPlay.addons.colorPalette.update(args);
+        // });
+        //
+        // // If is a new file load all colors by going to the end and comeback
+        // TangramPlay.on('sceneload', (event) => {
+        //     for (let i = 0; i < editor.getDoc().size; i++) {
+        //         jumpToLine(editor, i);
+        //     }
+        //     jumpToLine(editor, 0);
+        // });
     }
 
     update (args) {

--- a/src/js/widgets/color-palette.js
+++ b/src/js/widgets/color-palette.js
@@ -11,15 +11,14 @@ export default class ColorPalette {
         this.palette.className = 'colorpalette';
         document.body.appendChild(this.palette);
 
-        // TODO: replace this.
+        TangramPlay.on('widget_marks_created', (args) => {
+            TangramPlay.addons.colorPalette.update(args);
+        });
 
-        // TangramPlay.addons.widgetsManager.on('widgets_created', (args) => {
-        //     TangramPlay.addons.colorPalette.update(args);
-        // });
-        //
-        // TangramPlay.addons.widgetsManager.on('widget_updated', (args) => {
-        //     TangramPlay.addons.colorPalette.update(args);
-        // });
+        // TODO: This might not be triggered anywhere. Update or fix.
+        TangramPlay.on('widget_updated', (args) => {
+            TangramPlay.addons.colorPalette.update(args);
+        });
 
         // If is a new file load all colors by going to the end and comeback
         TangramPlay.on('sceneload', (event) => {

--- a/src/js/widgets/widget-type.js
+++ b/src/js/widgets/widget-type.js
@@ -5,12 +5,18 @@ import VectorButton from './vector-button';
 
 export default class WidgetType {
     constructor (datum) {
+        // Widgets exist for different types of Tangram scene syntax.
+        //      value - a widget exists for this type of value (not used?)
+        //      key - a widget exists when the key matches this
+        //      address - a widget exists when the address (sequence of keys)
+        //          matches this
         const matchTypes = [
             'value',
             'key',
             'address',
         ];
 
+        // This normalizes the syntax matching method to a single property.
         for (const key of matchTypes) {
             if (datum[key]) {
                 this.matchAgainst = key;
@@ -19,35 +25,36 @@ export default class WidgetType {
             }
         }
 
+        // The rest of the data is stored, with default values if not present
         this.type = datum.type;
         this.options = datum.options || [];
         this.source = datum.source || null;
     }
 
-    match (keyPair) {
+    match (node) {
         if (this.matchAgainst) {
-            return RegExp(this.matchPattern).test(keyPair[this.matchAgainst]);
+            return RegExp(this.matchPattern).test(node[this.matchAgainst]);
         }
         else {
             return false;
         }
     }
 
-    create (keyPair) {
+    create (node) {
         let widgetObj;
 
         switch (this.type) {
             case 'color':
-                widgetObj = new ColorButton(this, keyPair);
+                widgetObj = new ColorButton(this, node);
                 break;
             case 'boolean':
-                widgetObj = new ToggleButton(this, keyPair);
+                widgetObj = new ToggleButton(this, node);
                 break;
             case 'string':
-                widgetObj = new DropDownMenu(this, keyPair);
+                widgetObj = new DropDownMenu(this, node);
                 break;
             case 'vector':
-                widgetObj = new VectorButton(this, keyPair);
+                widgetObj = new VectorButton(this, node);
                 break;
             default:
                 // Nothing

--- a/src/js/widgets/widget-type.js
+++ b/src/js/widgets/widget-type.js
@@ -3,7 +3,7 @@ import ToggleButton from './toggle-button';
 import DropDownMenu from './drop-down-menu';
 import VectorButton from './vector-button';
 
-export default class WidgetType {
+export default class WidgetConstructor {
     constructor (datum) {
         // Widgets exist for different types of Tangram scene syntax.
         //      value - a widget exists for this type of value (not used?)

--- a/src/js/widgets/widget-type.js
+++ b/src/js/widgets/widget-type.js
@@ -3,7 +3,7 @@ import ToggleButton from './toggle-button';
 import DropDownMenu from './drop-down-menu';
 import VectorButton from './vector-button';
 
-export default class WidgetConstructor {
+export default class WidgetMarkConstructor {
     constructor (datum) {
         // Widgets exist for different types of Tangram scene syntax.
         //      value - a widget exists for this type of value (not used?)

--- a/src/js/widgets/widget.js
+++ b/src/js/widgets/widget.js
@@ -52,8 +52,6 @@ export default class Widget {
         }
         // Find the right widget to update if a line has multiple nodes
         else {
-            // Here is a good place to detect duplicates
-            // let others = editor.getDoc().findMarksAt(this.node.range.to);
             let node = TangramPlay.getNodesForAddress(this.node.address);
             this.node = node;
         }

--- a/src/js/widgets/widget.js
+++ b/src/js/widgets/widget.js
@@ -7,8 +7,8 @@
  *  with any additional functionality.
  *
  */
-import TangramPlay from '../tangram-play';
-import { editor } from '../editor/editor';
+import { editor, setNodeValue } from '../editor/editor';
+import { parseYamlString } from '../editor/codemirror/yaml-tangram';
 
 export default class Widget {
     constructor (def, node) {
@@ -28,21 +28,11 @@ export default class Widget {
         return document.createDocumentFragment();
     }
 
-    destroy () {
-        if (this.bookmark) {
-            this.bookmark.clear();
-        }
-    }
-
-    updateNode () {
+    updateNodeReference (lineNumber) {
         // Update a widget on a single-node line
-        if (this.bookmark &&
-            this.bookmark.lines &&
-            this.bookmark.lines.length === 1 &&
-            this.bookmark.lines[0] &&
-            this.bookmark.lines[0].stateAfter &&
-            this.bookmark.lines[0].stateAfter.nodes &&
-            this.bookmark.lines[0].stateAfter.nodes.length > 0) {
+        // If for any reason this doesn't work, there's an alternate way to
+        // find the right node.
+        if (this.bookmark) {
             for (let node of this.bookmark.lines[0].stateAfter.nodes) {
                 if (this.node.address === node.address) {
                     this.node = node;
@@ -50,22 +40,36 @@ export default class Widget {
                 }
             }
         }
-        // Find the right widget to update if a line has multiple nodes
-        else {
-            let node = TangramPlay.getNodesForAddress(this.node.address);
-            this.node = node;
+        // .getNodesForAddress is VERY slow, so let's avoid calling it
+        // if we can - either use the stored node, as above, or
+        // only parse the given line number our mark is on.
+        else if (lineNumber) {
+            const doc = editor.getDoc();
+            const text = doc.getLineHandle(lineNumber).text;
+            const dummyStateObject = {
+                keyStack: []
+            };
+            const state = parseYamlString(text, dummyStateObject, 4);
+
+            // Iterate through keys in this line
+            for (let node of state.nodes) {
+                if (node.address === this.node.address) {
+                    this.node = node;
+                    return;
+                }
+            }
         }
     }
 
     update () {
-        this.updateNode();
+        this.updateNodeReference();
         // This looks weird but is to force the use of 'get value ()' which
         // clean the anchors
         this.value = this.value;
     }
 
     insert (lineNumber) {
-        this.updateNode();
+        this.updateNodeReference(lineNumber);
 
         const doc = editor.getDoc();
 
@@ -123,10 +127,10 @@ export default class Widget {
      *  back to the Tangram Play editor.
      */
     setEditorValue (string) {
-        this.updateNode();
+        this.updateNodeReference();
 
         // Send the value to editor
-        TangramPlay.setValue(this.node, string);
+        setNodeValue(this.node, string, '+value_change');
 
         // Change the value attached to this widget instance
         this.node.value = string;

--- a/src/js/widgets/widget.js
+++ b/src/js/widgets/widget.js
@@ -64,10 +64,16 @@ export default class Widget {
         this.value = this.value;
     }
 
-    insert () {
+    insert (lineNumber) {
         this.updateNode();
 
         const doc = editor.getDoc();
+
+        // Update line number because
+        if (lineNumber) {
+            this.node.range.to.line = lineNumber;
+            this.node.range.from.line = lineNumber;
+        }
 
         // Do not insert if another bookmark is already inserted at this point
         const otherMarks = doc.findMarksAt(this.node.range.to);
@@ -90,6 +96,7 @@ export default class Widget {
         this.bookmark = doc.setBookmark(this.node.range.to, {
             widget: this.el,
             insertLeft: true,
+            clearWhenEmpty: true,
             handleMouseEvents: true
         });
         this.bookmark.widget = this;

--- a/src/js/widgets/widgets-manager.js
+++ b/src/js/widgets/widgets-manager.js
@@ -1,4 +1,5 @@
 import { editor } from '../editor/editor';
+import TangramPlay from '../tangram-play';
 
 /**
  * Initializes widget marks in the current editor viewport and adds event
@@ -58,15 +59,14 @@ function handleEditorChanges (cm, changes) {
 
 /**
  * Handler function for the CodeMirror `scroll` event.
+ * As the different parts of the viewport come into view, insert widget marks
+ * that may exist in the viewport.
  *
  * @param {CodeMirror} cm - instance of CodeMirror editor.
  */
 function handleEditorScroll (cm) {
     const viewport = cm.getViewport();
-    const fromLine = viewport.from;
-    const toLine = viewport.to;
-
-    insertMarks(fromLine, toLine);
+    insertMarks(viewport.from, viewport.to);
 }
 
 /**
@@ -116,10 +116,11 @@ function insertMarks (fromLine, toLine) {
     // If `to` is not provided, use `from`.
     toLine = (toLine || fromLine);
 
+    const newWidgets = [];
+
     // For each line in the range, get the line handle, check for nodes,
     // check for widgets, and add or remove them.
     for (let line = fromLine; line <= toLine; line++) {
-        const newWidgets = [];
         const doc = editor.getDoc();
         const lineHandle = doc.getLineHandle(line);
 
@@ -151,6 +152,6 @@ function insertMarks (fromLine, toLine) {
         }
     }
 
-    // TODO: replace this
-    // this.trigger('widgets_created', { widgets: newWidgets });
+    // Trigger an event for created widgets - this is picked up by the color palette
+    TangramPlay.trigger('widget_marks_created', { widgets: newWidgets });
 }

--- a/src/js/widgets/widgets-manager.js
+++ b/src/js/widgets/widgets-manager.js
@@ -141,9 +141,9 @@ function insertMarks (fromLine, toLine) {
             // if so, we create it and insert it into the document.
             // Skip blank lines, which may have the state (and widget
             // constructor) of the previous line.
-            if (node.widgetConstructor && lineHandle.text.trim() !== '') {
+            if (node.widgetMarkConstructor && lineHandle.text.trim() !== '') {
                 const lineNumber = doc.getLineNumber(lineHandle);
-                const widget = node.widgetConstructor.create(node);
+                const widget = node.widgetMarkConstructor.create(node);
                 if (widget.insert(lineNumber)) {
                     newWidgets.push(widget);
                 }

--- a/src/js/widgets/widgets-manager.js
+++ b/src/js/widgets/widgets-manager.js
@@ -1,201 +1,137 @@
-import TangramPlay from '../tangram-play';
-// import TANGRAM_API from '../tangram-api.json';
-// import WidgetType from './widget-type';
-import { editor, getNodesInRange } from '../editor/editor';
-// import { subscribeMixin } from '../tools/mixin';
-import { isEmptyString } from '../tools/helpers';
+import { editor } from '../editor/editor';
 
 export default class WidgetsManager {
     constructor () {
-        // subscribeMixin(this);
-        //
-        // this.data = []; // tokens to check
-        // this.pairedUntilLine = 0;
-        //
-        // // Initialize tokens
-        // for (let datum of TANGRAM_API.values) {
-        //     if (datum.type === 'color' || datum.type === 'vector' || datum.type === 'boolean' || datum.type === 'string') {
-        //         this.data.push(new WidgetType(datum));
-        //     }
-        // }
-        //
-        // let from = { line: 0, ch: 0 };
-        // let to = {
-        //     line: editor.getDoc().size - 1,
-        //     ch: editor.getLine(editor.getDoc().size - 1).length
-        // };
-        // this.createRange(from, to);
+        // On initialization, insert all marks in the current viewport.
+        const viewport = editor.getViewport();
+        insertMarks(viewport.from, viewport.to);
 
-        // // If something change only update that
-        // editor.on('changes', (cm, changesObjs) => {
-        //     // for (let obj of changesObjs) {
-        //     //     this.change(obj);
-        //     // }
-        // });
-        //
-        // // Keep track of possible NOT-PARSED lines
-        // // and in every codemirror "render update" check if we are approaching a
-        // // non-parsed area and for it to update by cleaning and creating
-        // editor.on('scroll', (cm) => {
-        //     let horizon = editor.getViewport().to - 1;
-        //     if (this.pairedUntilLine < horizon) {
-        //         let from = {
-        //             line: this.pairedUntilLine + 1,
-        //             ch: 0
-        //         };
-        //         let to = {
-        //             line: horizon,
-        //             ch: editor.getLine(horizon).length
-        //         };
-        //         this.clearRange(from, to);
-        //         this.createRange(from, to);
-        //     }
-        // });
+        // On editor changes, update those marks
+        editor.on('changes', (cm, changes) => {
+            for (let change of changes) {
+                // Each change object specifies a range of lines
+                let fromLine = change.from.line;
+                let toLine = change.to.line;
 
-        editor.on('renderLine', function (cm, line, el) {
-            for (let node of line.stateAfter.nodes) {
-                if (node.widget) {
-                    let nodeCopy = _.clone(node);
-                    let widget = node.widget.create(nodeCopy);
-                    widget.insert();
+                // CodeMirror's `from` and `to` properties are pre-change values, so
+                // we adjust the range if lines were removed or added. The `removed`
+                // and `text` properties are arrays which indicate how many lines
+                // were removed or added respectively.
+                if (change.origin === '+delete' || change.origin === 'cut') {
+                    // In a delete or cut operation, CodeMirror's `to` line
+                    // includes lines have just been removed. However, we don't
+                    // want to parse those lines, since they're gone. We will
+                    // only reparse the current line.
+                    toLine = fromLine;
                 }
+                else if (change.origin === 'paste' || change.origin === 'undo') {
+                    // In a paste operation, CodeMirror's to line is the same
+                    // as the from line. We can get the correct to-line by
+                    // adding the pasted lines minus the removed lines.
+                    // This also captures undo operations where removals of
+                    // lines are undone (so it works like a paste)
+                    toLine += change.text.length - change.removed.length;
+                }
+
+                clearMarks(fromLine, toLine);
+                insertMarks(fromLine, toLine);
             }
         });
 
-        // If a new files is loaded reset the tracked line
-        // TangramPlay.on('sceneload', (event) => {
-        //     this.pairedUntilLine = 0;
-        // });
-    }
-    //
-    // change (changeObj) {
-    //     // Get FROM/TO range of the change
-    //     let from = { line: changeObj.from.line, ch: changeObj.from.ch };
-    //     let to = { line: changeObj.to.line, ch: changeObj.to.ch };
-    //
-    //     if (changeObj.removed.length > changeObj.text.length) {
-    //         from.line -= changeObj.removed.length - 1;
-    //         to.line += 1;
-    //     }
-    //     else if (changeObj.removed.length < changeObj.text.length) {
-    //         to.line = changeObj.from.line + changeObj.text.length - 1;
-    //     }
-    //
-    //     to.ch = editor.getLine(to.line) ? editor.getLine(to.line).length : 0;
-    //
-    //     // If is a new line move the range FROM the begining of the line
-    //     if (changeObj.text.length === 2 &&
-    //         changeObj.text[0] === '' &&
-    //         changeObj.text[1] === '') {
-    //         from.ch = 0;
-    //     }
-    //
-    //     // Get the matching nodes for the FROM/TO range
-    //     let nodes = getNodesInRange(from, to);
-    //     // If there is no nodes there nothing to do
-    //     if (!nodes || nodes.length === 0) {
-    //         return;
-    //     }
-    //
-    //     // Get affected bookmarks
-    //     let bookmarks = [];
-    //     if (from.line === to.line && from.ch === to.ch) {
-    //         // If the FROM/TO range is to narrow search using nodes
-    //         for (let node of nodes) {
-    //             // Find and concatenate bookmarks between FROM/TO range
-    //             bookmarks = bookmarks.concat(editor.getDoc().findMarksAt(node.range.to));
-    //         }
-    //     }
-    //     else {
-    //         bookmarks = editor.getDoc().findMarksAt(to);
-    //     }
-    //
-    //     // If there is only one node and the change happen on the value
-    //     if (nodes.length === 1 &&
-    //         bookmarks.length === 1 &&
-    //         from.ch > (nodes[0].range.from.ch + nodes[0].key.length + 2) &&
-    //         bookmarks[0].widget) {
-    //         // console.log("Updating value of ", bookmarks[0]);
-    //         // Update the widget
-    //         bookmarks[0].widget.update();
-    //         // Trigger Events
-    //         this.trigger('widget_updated', { widgets: bookmarks[0].widget });
-    //     }
-    //     else {
-    //         // Delete those afected widgets
-    //         for (let bkm of bookmarks) {
-    //             bkm.clear();
-    //         }
-    //
-    //         // Create widgets from nodes
-    //         this.createWidget(nodes);
-    //     }
-    // }
-    //
-    // clearRange (from, to) {
-    //     let nodes = getNodesInRange(from, to);
-    //
-    //     if (!nodes || nodes.length === 0) {
-    //         return;
-    //     }
-    //
-    //     this.clearNodes(nodes);
-    // }
-    //
-    // clearNodes (nodes) {
-    //     let doc = editor.getDoc();
-    //     for (let node of nodes) {
-    //         // Find bookmarks between FROM and TO
-    //         let from = node.range.from.line;
-    //         let to = node.range.to.line;
-    //         let bookmarks = doc.findMarks({ line: from }, { line: to });
-    //
-    //         // Delete those with widgets
-    //         for (let bkm of bookmarks) {
-    //             bkm.clear();
-    //         }
-    //     }
-    // }
-    //
-    // createRange (from, to) {
-    //     // Search for nodes between FROM and TO
-    //     let nodes = getNodesInRange(from, to);
-    //
-    //     if (!nodes || nodes.length === 0) {
-    //         return;
-    //     }
-    //
-    //     this.createWidget(nodes);
-    // }
+        // CodeMirror only parses lines inside of the current viewport.
+        // When we scroll, we start inserting marks on lines as they're parsed.
+        editor.on('scroll', (cm) => {
+            const viewport = cm.getViewport();
+            const fromLine = viewport.from;
+            const toLine = viewport.to;
 
-    createWidget (nodes) {
-        // let newWidgets = [];
-        //
-        // console.error('createWidget is called');
-        // for (let node of nodes) {
-        //     let val = node.value;
-        //     if (val === '|' || isEmptyString(val) || isEmptyString(editor.getLine(node.range.from.line))) {
-        //         continue;
-        //     }
-        //
-        //     // Check for widgets to add
-        //     for (let datum of this.data) {
-        //         if (datum.match(node)) {
-        //             // Create node
-        //             let widget = datum.create(node);
-        //             if (widget.insert()) {
-        //                 newWidgets.push(widget);
-        //             }
-        //
-        //             if (this.pairedUntilLine < node.range.from.line) {
-        //                 this.pairedUntilLine = node.range.from.line;
-        //             }
-        //             break;
-        //         }
-        //     }
-        // }
-
-        // Trigger Events
-        this.trigger('widgets_created', { widgets: newWidgets });
+            insertMarks(fromLine, toLine);
+        });
     }
+}
+
+/**
+ * @param {Number} fromLine - The line number to clear from
+ * @param {Number} toLine - Optional. The line number to clear to. If not
+ *          provided, just the fromLine is checked.
+ */
+function clearMarks (fromLine, toLine) {
+    // If `to` is not provided, use `from`.
+    // Add one to this, so we check the entirety of the `to` line.
+    // TODO: verify this works (or we have to get the last character of the `to` line.)
+    toLine = (toLine || fromLine) + 1;
+
+    const doc = editor.getDoc();
+
+    // Create a range just for this line.
+    const fromPos = { line: fromLine, ch: 0 };
+    const toPos = { line: toLine, ch: 0 };
+
+    // Look for stray bookmarks
+    let strayBookmarks = doc.findMarks(fromPos, toPos) || [];
+
+    // findMarks() does not find marks that are at the end of a line, but not
+    // in the range provided. (This might be a CodeMirror bug?)
+    // Manually look for stray bookmarks at the end of these lines, as well.
+    for (let line = fromLine; line < toLine; line++) {
+        const lineContent = doc.getLine(line) || '';
+        const lineLength = lineContent.length;
+        const marks = doc.findMarksAt({ line: line, ch: lineLength });
+        strayBookmarks = strayBookmarks.concat(marks);
+    }
+
+    // And remove them, if present.
+    for (let bookmark of strayBookmarks) {
+        bookmark.clear();
+    }
+}
+
+/**
+ *
+ * @param {Number} fromLine - The line number to insert from
+ * @param {Number} toLine - Optional. The line number to insert to. If not
+ *          provided, just the fromLine is checked.
+ *
+ */
+function insertMarks (fromLine, toLine) {
+    // If `to` is not provided, use `from`.
+    toLine = (toLine || fromLine);
+
+    // For each line in the range, get the line handle, check for nodes,
+    // check for widgets, and add or remove them.
+    for (let line = fromLine; line <= toLine; line++) {
+        const newWidgets = [];
+        const doc = editor.getDoc();
+        const lineHandle = doc.getLineHandle(line);
+
+        // If no lineHandle, then CodeMirror probably has not parsed it yet;
+        // continue
+        if (!lineHandle || !lineHandle.stateAfter) {
+            continue;
+        }
+
+        const nodes = lineHandle.stateAfter.nodes || null;
+
+        // If there are no nodes, go to the next line
+        if (!nodes) {
+            continue;
+        }
+
+        for (let node of nodes) {
+            // See if there's a widget constructor attached to it, and
+            // if so, we create it and insert it into the document.
+            // Skip blank lines, which may have the state (and widget
+            // constructor) of the previous line.
+            if (node.widgetConstructor && lineHandle.text.trim() !== '') {
+                const lineNumber = doc.getLineNumber(lineHandle);
+                const widget = node.widgetConstructor.create(node);
+                if (widget.insert(lineNumber)) {
+                    newWidgets.push(widget);
+                }
+            }
+        }
+    }
+
+    // TODO: replace this
+    // this.trigger('widgets_created', { widgets: newWidgets });
 }

--- a/src/js/widgets/widgets-manager.js
+++ b/src/js/widgets/widgets-manager.js
@@ -1,5 +1,5 @@
 import { editor } from '../editor/editor';
-import TangramPlay from '../tangram-play';
+import { EventEmitter } from '../components/event-emitter';
 
 /**
  * Initializes widget marks in the current editor viewport and adds event
@@ -186,5 +186,5 @@ function insertMarks (fromLine, toLine) {
     }
 
     // Trigger an event for created widgets - this is picked up by the color palette
-    TangramPlay.trigger('widget_marks_created', { widgets: newWidgets });
+    EventEmitter.dispatch('widget_marks_created', { widgets: newWidgets });
 }

--- a/src/js/widgets/widgets-manager.js
+++ b/src/js/widgets/widgets-manager.js
@@ -1,213 +1,200 @@
 import TangramPlay from '../tangram-play';
-import TANGRAM_API from '../tangram-api.json';
-import WidgetType from './widget-type';
+// import TANGRAM_API from '../tangram-api.json';
+// import WidgetType from './widget-type';
 import { editor, getNodesInRange } from '../editor/editor';
-import { subscribeMixin } from '../tools/mixin';
+// import { subscribeMixin } from '../tools/mixin';
 import { isEmptyString } from '../tools/helpers';
 
 export default class WidgetsManager {
     constructor () {
-        subscribeMixin(this);
+        // subscribeMixin(this);
+        //
+        // this.data = []; // tokens to check
+        // this.pairedUntilLine = 0;
+        //
+        // // Initialize tokens
+        // for (let datum of TANGRAM_API.values) {
+        //     if (datum.type === 'color' || datum.type === 'vector' || datum.type === 'boolean' || datum.type === 'string') {
+        //         this.data.push(new WidgetType(datum));
+        //     }
+        // }
+        //
+        // let from = { line: 0, ch: 0 };
+        // let to = {
+        //     line: editor.getDoc().size - 1,
+        //     ch: editor.getLine(editor.getDoc().size - 1).length
+        // };
+        // this.createRange(from, to);
 
-        this.data = []; // tokens to check
-        this.pairedUntilLine = 0;
+        // // If something change only update that
+        // editor.on('changes', (cm, changesObjs) => {
+        //     // for (let obj of changesObjs) {
+        //     //     this.change(obj);
+        //     // }
+        // });
+        //
+        // // Keep track of possible NOT-PARSED lines
+        // // and in every codemirror "render update" check if we are approaching a
+        // // non-parsed area and for it to update by cleaning and creating
+        // editor.on('scroll', (cm) => {
+        //     let horizon = editor.getViewport().to - 1;
+        //     if (this.pairedUntilLine < horizon) {
+        //         let from = {
+        //             line: this.pairedUntilLine + 1,
+        //             ch: 0
+        //         };
+        //         let to = {
+        //             line: horizon,
+        //             ch: editor.getLine(horizon).length
+        //         };
+        //         this.clearRange(from, to);
+        //         this.createRange(from, to);
+        //     }
+        // });
 
-        // Initialize tokens
-        for (let datum of TANGRAM_API.values) {
-            if (datum.type === 'color' || datum.type === 'vector' || datum.type === 'boolean' || datum.type === 'string') {
-                this.data.push(new WidgetType(datum));
-            }
-        }
-
-        let from = { line: 0, ch: 0 };
-        let to = {
-            // Last line in viewport CodeMirror
-            line: editor.getDoc().size - 1,
-            // Last character in last line
-            ch: editor.getLine(editor.getDoc().size - 1).length
-        };
-        this.createRange(from, to);
-
-        // If something change only update that
-        editor.on('changes', (cm, changesObjs) => {
-            for (let obj of changesObjs) {
-                this.change(obj);
-            }
-        });
-
-        // Keep track of possible NOT-PARSED lines
-        // and in every codemirror 'render update' check if we are approaching a
-        // non-parsed area and for it to update by cleaning and creating
-        editor.on('scroll', (cm) => {
-            let horizon = editor.getViewport().to - 1;
-            if (this.pairedUntilLine < horizon) {
-                let from = {
-                    line: this.pairedUntilLine + 1,
-                    ch: 0
-                };
-                let to = {
-                    line: horizon,
-                    ch: editor.getLine(horizon).length
-                };
-                this.clearRange(from, to);
-                this.createRange(from, to);
+        editor.on('renderLine', function (cm, line, el) {
+            for (let node of line.stateAfter.nodes) {
+                if (node.widget) {
+                    let nodeCopy = _.clone(node);
+                    let widget = node.widget.create(nodeCopy);
+                    widget.insert();
+                }
             }
         });
 
         // If a new files is loaded reset the tracked line
-        TangramPlay.on('sceneload', (event) => {
-            this.pairedUntilLine = 0;
-        });
+        // TangramPlay.on('sceneload', (event) => {
+        //     this.pairedUntilLine = 0;
+        // });
     }
-
-    change (changeObj) {
-        // Get FROM/TO range of the change
-        let from = { line: changeObj.from.line, ch: changeObj.from.ch };
-        let to = { line: changeObj.to.line, ch: changeObj.to.ch };
-
-        // Simplest case. If a user is typing on a single line
-        let bookmarks = [];
-        if (from.line === to.line) { // Line the user is typing
-            // cascade and check up the tree and down the tree
-            var activeAddress = editor.getStateAfter(from.line).nodes[0].address;
-            bookmarks = bookmarks.concat(editor.getDoc().findMarksAt(to));
-
-            // If there is a bookmark on that line
-            if (bookmarks[0] !== undefined) {
-                let bookmarkAddress = bookmarks[0].widget.node.address;
-
-                // If the widget address does not correspond to the node address, it means user has deleted part of the logic
-                if (activeAddress !== bookmarkAddress) {
-                    for (let bkm of bookmarks) {
-                        bkm.clear(); // delete the widget
-                    }
-                    return;
-                }
-            }
-        }
-
-        // Cascade up and down using address
-        // Ex: layers:water iterate lines down until match level??
-        //
-        if (changeObj.removed.length > changeObj.text.length) {
-            from.line -= changeObj.removed.length - 1;
-            to.line += 1;
-        }
-        else if (changeObj.removed.length < changeObj.text.length) {
-            to.line = changeObj.from.line + changeObj.text.length - 1;
-        }
-
-        to.ch = editor.getLine(to.line) ? editor.getLine(to.line).length : 0;
-
-        // If is a new line move the range FROM the begining of the line
-        if (changeObj.text.length === 2 &&
-            changeObj.text[0] === '' &&
-            changeObj.text[1] === '') {
-            from.ch = 0;
-        }
-
-        // Get the matching nodes for the FROM/TO range
-        let nodes = getNodesInRange(from, to);
-        // If there is no nodes there nothing to do
-        if (!nodes || nodes.length === 0) {
-            return;
-        }
-
-        // Get affected bookmarks
-        bookmarks = [];
-        if (from.line === to.line && from.ch === to.ch) {
-            // If the FROM/TO range is to narrow search using nodes
-            for (let node of nodes) {
-                // Find and concatenate bookmarks between FROM/TO range
-                bookmarks = bookmarks.concat(editor.getDoc().findMarksAt(node.range.to));
-            }
-        }
-        else {
-            bookmarks = editor.getDoc().findMarksAt(to);
-        }
-
-        // If there is only one node and the change happen on the value
-        if (nodes.length === 1 &&
-            bookmarks.length === 1 &&
-            from.ch > (nodes[0].range.from.ch + nodes[0].key.length + 2) &&
-            bookmarks[0].widget) {
-            // console.log('Updating value of ', bookmarks[0]);
-            // Update the widget
-            bookmarks[0].widget.update();
-            // Trigger Events
-            this.trigger('widget_updated', { widgets: bookmarks[0].widget });
-        }
-        else {
-            // Delete those afected widgets
-            for (let bkm of bookmarks) {
-                bkm.clear();
-            }
-
-            // Create widgets from nodes
-            this.createWidget(nodes);
-        }
-    }
-
-    clearRange (from, to) {
-        let nodes = getNodesInRange(from, to);
-
-        if (!nodes || nodes.length === 0) {
-            return;
-        }
-
-        this.clearNodes(nodes);
-    }
-
-    clearNodes (nodes) {
-        let doc = editor.getDoc();
-        for (let node of nodes) {
-            // Find bookmarks between FROM and TO
-            let from = node.range.from.line;
-            let to = node.range.to.line;
-            let bookmarks = doc.findMarks({ line: from }, { line: to });
-
-            // Delete those with widgets
-            for (let bkm of bookmarks) {
-                bkm.clear();
-            }
-        }
-    }
-
-    createRange (from, to) {
-        // Search for nodes between FROM and TO
-        let nodes = getNodesInRange(from, to);
-
-        if (!nodes || nodes.length === 0) {
-            return;
-        }
-
-        this.createWidget(nodes);
-    }
+    //
+    // change (changeObj) {
+    //     // Get FROM/TO range of the change
+    //     let from = { line: changeObj.from.line, ch: changeObj.from.ch };
+    //     let to = { line: changeObj.to.line, ch: changeObj.to.ch };
+    //
+    //     if (changeObj.removed.length > changeObj.text.length) {
+    //         from.line -= changeObj.removed.length - 1;
+    //         to.line += 1;
+    //     }
+    //     else if (changeObj.removed.length < changeObj.text.length) {
+    //         to.line = changeObj.from.line + changeObj.text.length - 1;
+    //     }
+    //
+    //     to.ch = editor.getLine(to.line) ? editor.getLine(to.line).length : 0;
+    //
+    //     // If is a new line move the range FROM the begining of the line
+    //     if (changeObj.text.length === 2 &&
+    //         changeObj.text[0] === '' &&
+    //         changeObj.text[1] === '') {
+    //         from.ch = 0;
+    //     }
+    //
+    //     // Get the matching nodes for the FROM/TO range
+    //     let nodes = getNodesInRange(from, to);
+    //     // If there is no nodes there nothing to do
+    //     if (!nodes || nodes.length === 0) {
+    //         return;
+    //     }
+    //
+    //     // Get affected bookmarks
+    //     let bookmarks = [];
+    //     if (from.line === to.line && from.ch === to.ch) {
+    //         // If the FROM/TO range is to narrow search using nodes
+    //         for (let node of nodes) {
+    //             // Find and concatenate bookmarks between FROM/TO range
+    //             bookmarks = bookmarks.concat(editor.getDoc().findMarksAt(node.range.to));
+    //         }
+    //     }
+    //     else {
+    //         bookmarks = editor.getDoc().findMarksAt(to);
+    //     }
+    //
+    //     // If there is only one node and the change happen on the value
+    //     if (nodes.length === 1 &&
+    //         bookmarks.length === 1 &&
+    //         from.ch > (nodes[0].range.from.ch + nodes[0].key.length + 2) &&
+    //         bookmarks[0].widget) {
+    //         // console.log("Updating value of ", bookmarks[0]);
+    //         // Update the widget
+    //         bookmarks[0].widget.update();
+    //         // Trigger Events
+    //         this.trigger('widget_updated', { widgets: bookmarks[0].widget });
+    //     }
+    //     else {
+    //         // Delete those afected widgets
+    //         for (let bkm of bookmarks) {
+    //             bkm.clear();
+    //         }
+    //
+    //         // Create widgets from nodes
+    //         this.createWidget(nodes);
+    //     }
+    // }
+    //
+    // clearRange (from, to) {
+    //     let nodes = getNodesInRange(from, to);
+    //
+    //     if (!nodes || nodes.length === 0) {
+    //         return;
+    //     }
+    //
+    //     this.clearNodes(nodes);
+    // }
+    //
+    // clearNodes (nodes) {
+    //     let doc = editor.getDoc();
+    //     for (let node of nodes) {
+    //         // Find bookmarks between FROM and TO
+    //         let from = node.range.from.line;
+    //         let to = node.range.to.line;
+    //         let bookmarks = doc.findMarks({ line: from }, { line: to });
+    //
+    //         // Delete those with widgets
+    //         for (let bkm of bookmarks) {
+    //             bkm.clear();
+    //         }
+    //     }
+    // }
+    //
+    // createRange (from, to) {
+    //     // Search for nodes between FROM and TO
+    //     let nodes = getNodesInRange(from, to);
+    //
+    //     if (!nodes || nodes.length === 0) {
+    //         return;
+    //     }
+    //
+    //     this.createWidget(nodes);
+    // }
 
     createWidget (nodes) {
-        let newWidgets = [];
-        for (let node of nodes) {
-            let val = node.value;
-            if (val === '|' || isEmptyString(val) || isEmptyString(editor.getLine(node.range.from.line))) {
-                continue;
-            }
+        // let newWidgets = [];
+        //
+        // console.error('createWidget is called');
+        // for (let node of nodes) {
+        //     let val = node.value;
+        //     if (val === '|' || isEmptyString(val) || isEmptyString(editor.getLine(node.range.from.line))) {
+        //         continue;
+        //     }
+        //
+        //     // Check for widgets to add
+        //     for (let datum of this.data) {
+        //         if (datum.match(node)) {
+        //             // Create node
+        //             let widget = datum.create(node);
+        //             if (widget.insert()) {
+        //                 newWidgets.push(widget);
+        //             }
+        //
+        //             if (this.pairedUntilLine < node.range.from.line) {
+        //                 this.pairedUntilLine = node.range.from.line;
+        //             }
+        //             break;
+        //         }
+        //     }
+        // }
 
-            // Check for widgets to add
-            for (let datum of this.data) {
-                if (datum.match(node)) {
-                    // Create node
-                    let widget = datum.create(node);
-                    if (widget.insert()) {
-                        newWidgets.push(widget);
-                    }
-
-                    if (this.pairedUntilLine < node.range.from.line) {
-                        this.pairedUntilLine = node.range.from.line;
-                    }
-                    break;
-                }
-            }
-        }
         // Trigger Events
         this.trigger('widgets_created', { widgets: newWidgets });
     }


### PR DESCRIPTION
This is the "widgets-should-not-break-anymore" pull request. It touches a lot of CodeMirror internals, and here's the brief summary of major infrastructure changes from before:

## Editor

- Continued work on the YAML-Tangram mode's handling of inner modes. The model is similar to what's described in an earlier pull request (https://github.com/tangrams/tangram-play/pull/392), but it turns out that delegating to JS or C-like on a per-line basis is not that feasible, at least not in the ways I've tried. Now, it still switches to inner modes for the duration, but is smarter about when it makes the switch. One noticeable fix for this is that if your cursor is at the end of the first line of this block:

```yaml
global: |
   // GLSL code here
```

It treats the entirety of that line properly as YAML. Previously, GLSL mode started at the colon, parsing the pipe character (`|`) improperly as GLSL. Now, GLSL mode does not begin until the next line, as expected.
- Editor functionality is continues to be refactored out of `tangram-play.js` and live in the `editor` module as opposed methods on the `TangramPlay` "god" object.

## Widgets

- "Widgets" is a strange term because it refers to two different concepts: the first is an in-line marker, attached to a YAML value, which indicates the existence of an interactive UI to help select valid values. The second use of the term is the popup UI itself, a floating box on top of the editor that appears when the inline-marker is clicked. Using this term interchangeably is confusing because it does not allow us to be clear about what we are referring to. Since most of the work in the PR addresses the inline markers, I have started to use the term "widget mark" or "widget marker" to refer to them.
- Widget markers are now closely associated with CodeMirror line handles. When CodeMirror parses a line, and the line has nodes that match widget types, then the constructor for the widget markers to display is stored on the node itself. This allows the each line that is rendered to know what markers to display. And because each marker is associated with a line, the marker does not need to know about the existence of other lines. Previously, we relied on the node's internal state record of the line number, but it turns out this is unreliable because CodeMirror does not always automatically update all the node states when changes occur elsewhere in the document; now, the marker can only exist on the line it's attached to, and there should be no chance that a marker will ever display on a different line.
- Since widget marker insertion happens with line rendering, we can start inserting widget markers immediately as the editor content is parsed -- previously, there would be a second or so of delay which waited for the document to be opened, parsed, and inserted into Tangram before widget markers would appear.
- The logic behind erasing and inserting markers when necessary have been rewritten to be (hopefully) clearer, especially when handling different cases of how inputs in the editor can be added or deleted (e.g. multi-line inserts, deletes, cut and pastes), and weird edges in CodeMirror on blank lines that leave stray widget markers floating in space. One performance tweak is to match CodeMirror's rendering behavior by only display widget markers in the visible viewport.
- Additional performance tweak that improves rendering in large YAML documents (like Mapzen house styles), ensuring that widget popups do not need to search through an entire document to find its marker. This should dramatically improve the jankiness that could ensue when scrolling through & rendering the widget markers of 3000+ lines of YAML.

Please continue to try to break inline widget markers on the branch, @bcamper @meetar @nvkelso @burritojustice. I'm pretty confident in this so far, and would like to get some 👍 and merge by tomorrow, Wednesday 1pm EST.