### PR TITLE
Convert file drop to React component

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,12 +145,7 @@
                 <button class='modal-confirm' disabled><i class='btm bt-check'></i> Open</button>
             </div>
         </div>
-        <div class='filedrop-container' id='filedrop'>
-            <div class='filedrop-indicator'>
-                <div class='filedrop-icon'><i class='btm bt-upload'></i></div>
-                <div class='filedrop-label'>Drop a file here to open</div>
-            </div>
-        </div>
+        <div id='filedrop'></div>
     </div>
 
     <div id='mobile-message' class='mobile-message'>

--- a/src/js/file/drop.js
+++ b/src/js/file/drop.js
@@ -1,64 +1,104 @@
+import React from 'react';
+import Icon from '../components/icon.react';
 import EditorIO from '../editor/io';
 
-const el = document.getElementById('filedrop');
+export default class FileDrop extends React.Component {
+    constructor (props) {
+        super(props);
 
-// Set up drag/drop file listeners
-window.addEventListener('dragenter', (event) => {
-    // Check to make sure that dropped items are files.
-    // This prevents other drags (e.g. text in editor)
-    // from turning on the file drop area.
-    // See here: http://stackoverflow.com/questions/6848043/how-do-i-detect-a-file-is-being-dragged-rather-than-a-draggable-element-on-my-pa
-    // Tested in Chrome, Firefox, Safari 8
-    var types = event.dataTransfer.types;
-    if (types !== null && ((types.indexOf) ? (types.indexOf('Files') !== -1) : types.contains('application/x-moz-file'))) {
-        event.preventDefault();
-        event.dataTransfer.dropEffect = 'copy';
-        showFileDropArea();
+        this.state = {
+            visibleFileDropArea: false
+        };
+
+        this._onDragEnter = this._onDragEnter.bind(this);
+        this._onDragOver = this._onDragOver.bind(this);
+        this._onDragLeave = this._onDragLeave.bind(this);
+        this._onDrop = this._onDrop.bind(this);
     }
-}, true);
 
-el.addEventListener('dragover', (event) => {
+    render () {
+        const displayStyle = this.state.visibleFileDropArea
+            ? { display: 'block' }
+            : { display: 'none' };
+
+        return (
+            <div className='filedrop-container' onDragEnter={this._onDragEnter} onDragLeave={this._onDragLeave} onDrop={this._onDrop} style={displayStyle}>
+                <div className='filedrop-indicator'>
+                    <div className='filedrop-icon'>
+                        <Icon type={'bt-upload'} />
+                    </div>
+                    <div className='filedrop-label'>Drop a file here to open</div>
+                </div>
+            </div>
+        );
+    }
+
+    // Set up drag/drop file event listeners to the window`
+    componentWillMount () {
+        // Capturing events here prevents them from getting delivered to CodeMirror
+        // or resulting in a file navigation
+        window.addEventListener('dragenter', this._onDragEnter, true);
+        window.addEventListener('dragover', this._onDragOver, true);
+        window.addEventListener('drop', this._handleDropOnWindow, true);
+    }
+
+    // This handler is added to the window during the componentWillMount step
+    _onDragEnter (event) {
+        // Check to make sure that dropped items are files.
+        // This prevents other drags (e.g. text in editor)
+        // from turning on the file drop area.
+        // See here: http://stackoverflow.com/questions/6848043/how-do-i-detect-a-file-is-being-dragged-rather-than-a-draggable-element-on-my-pa
+        // Tested in Chrome, Firefox, Safari 8
+        const types = event.dataTransfer.types;
+        if (types !== null && ((types.indexOf) ? (types.indexOf('Files') !== -1) : types.contains('application/x-moz-file'))) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'copy';
+            this.setState({ visibleFileDropArea: true });
+        }
+    }
+
     // Required to prevent browser from navigating to a file
     // instead of receiving a data transfer
-    event.preventDefault();
-
-    // On Mac + Chrome, drag-and-dropping a scene file from the downloads bar
-    // will silently fail. The drop event is never fired on the drop area.
-    // This issue is tracked here: https://github.com/tangrams/tangram-play/issues/228
-    // The Chrome bug is tracked here:
-    // https://code.google.com/p/chromium/issues/detail?id=234931
-    // Based on a comment in that thread, manually setting the dropEffect in this
-    // way will solve this problem.
-    let effect = event.dataTransfer && event.dataTransfer.dropEffect;
-    let effectAllowed = event.dataTransfer && event.dataTransfer.effectAllowed;
-    if (effect !== 'none' || effectAllowed === 'none') {
-        return;
+    _handleDropOnWindow (event) {
+        event.preventDefault();
     }
-    event.dataTransfer.dropEffect = 'copy';
-}, false);
 
-el.addEventListener('dragleave', (event) => {
-    event.preventDefault();
-    hideFileDropArea();
-}, true);
+    // This handler is added to the drop area when it is rendered
+    _onDragOver (event) {
+        // Required to prevent browser from navigating to a file
+        // instead of receiving a data transfer
+        event.preventDefault();
 
-el.addEventListener('drop', (event) => {
-    event.preventDefault();
-    hideFileDropArea();
-    onDropFile(event.dataTransfer.files);
-}, false);
+        // On Mac + Chrome, drag-and-dropping a scene file from the downloads bar
+        // will silently fail. The drop event is never fired on the drop area.
+        // This issue is tracked here: https://github.com/tangrams/tangram-play/issues/228
+        // The Chrome bug is tracked here:
+        // https://code.google.com/p/chromium/issues/detail?id=234931
+        // Based on a comment in that thread, manually setting the dropEffect in this
+        // way will solve this problem.
+        const effect = event.dataTransfer && event.dataTransfer.dropEffect;
+        const effectAllowed = event.dataTransfer && event.dataTransfer.effectAllowed;
+        if (effect !== 'none' || effectAllowed === 'none') {
+            return;
+        }
+        event.dataTransfer.dropEffect = 'copy';
+    }
 
-function showFileDropArea () {
-    el.style.display = 'block';
-}
+    _onDragLeave (event) {
+        event.preventDefault();
+        this.setState({ visibleFileDropArea: false });
+    }
 
-function hideFileDropArea () {
-    el.style.display = 'none';
-}
+    _onDrop (event) {
+        event.preventDefault();
+        this.setState({ visibleFileDropArea: false });
+        this._handleFiles(event.dataTransfer.files);
+    }
 
-function onDropFile (files) {
-    if (files.length > 0) {
-        const file = files[0];
-        EditorIO.open(file);
+    _handleFiles (files) {
+        if (files.length > 0) {
+            const file = files[0];
+            EditorIO.open(file);
+        }
     }
 }

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -37,7 +37,6 @@ import { highlightLines } from './editor/highlight';
 
 // Import UI elements
 import { initDivider } from './ui/divider';
-import './file/drop';
 import './ui/tooltip';
 
 const query = getQueryStringObject();
@@ -432,9 +431,13 @@ var ReactDOM = require('react-dom');
 
 import MenuBar from './components/menu-bar.react';
 import MapPanel from './components/map-panel.react';
+import FileDrop from './file/drop';
 
 let mountNode1 = document.getElementById('menu-bar');
 ReactDOM.render(<MenuBar />, mountNode1);
 
 let mountNode2 = document.getElementById('map-panel');
 ReactDOM.render(<MapPanel />, mountNode2);
+
+let mountNode3 = document.getElementById('filedrop');
+ReactDOM.render(<FileDrop />, mountNode3);


### PR DESCRIPTION
@irealva Thought I'd start picking off some other Reactification myself! The file drop component seemed like an easy place to start, since it's a pretty standalone piece of functionality, and very small. I figured I would go for a straight conversion of existing code rather than re-implementing it from scratch or with a third-party library. It worked out pretty well -- there's just some additional event handlers on `window` that I had to put in (maybe because React event handlers work slightly differently?)

Please give it a quick review and let me know how it looks!