### PR TITLE
Remove fetching with credentials

### DIFF
--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -170,13 +170,13 @@ class TangramPlay {
                         // Update the scene URL property with the correct URL
                         // to the raw YAML to ensure safe loading
                         scene.url = url;
-                        return window.fetch(url, { credentials: 'same-origin' });
+                        return window.fetch(url);
                     });
             }
             // Fetch the contents of a YAML file directly. This step
             // allows us to verify contents (TODO) or error status.
             else {
-                fetchPromise = window.fetch(scene.url, { credentials: 'same-origin' });
+                fetchPromise = window.fetch(scene.url);
             }
 
             return fetchPromise.then(response => {


### PR DESCRIPTION
This removes the `credentials` option from `fetch` requests, which was added only to support asynchronous reading of local YAML files on Precog. It is never needed for production or for local builds of Tangram Play. 

See also: https://github.com/mapzen/precog/pull/46