### PR TITLE
Cache example scene files

### DIFF
--- a/data/scenes/default.yaml
+++ b/data/scenes/default.yaml
@@ -1,14 +1,10 @@
-scene:
-    background:
-        color: '#353535'
-
 cameras:
     perspective:
         type: perspective
         vanishing_point: [0, -500]
 
 lights:
-    light1:
+    directional1:
         type: directional
         direction: [.1, .5, -1]
         diffuse: .7
@@ -25,16 +21,9 @@ styles:
 sources:
     mapzen:
         type: TopoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson?api_key=vector-tiles-JUsa0Gc
 
 layers:
-    earth:
-        data: { source: mapzen }
-        draw:
-            polygons:
-                order: 0
-                color: '#555'
-
     water:
         data: { source: mapzen }
         draw:
@@ -42,13 +31,20 @@ layers:
                 order: 2
                 color: '#353535'
 
+    earth:
+        data: { source: mapzen }
+        draw:
+            polygons:
+                order: 0
+                color: '#555'
+
     landuse:
         data: { source: mapzen }
         draw:
             polygons:
                 order: 1
                 color: '#666'
-                
+
     roads:
         data: { source: mapzen }
         filter: { not: { kind: ferry } }
@@ -57,29 +53,25 @@ layers:
                 order: 2
                 color: '#777'
                 width: 5
-
         labels:
-            filter:
-                name: true
-                aeroway: false
-                tunnel: false
-                railway: false
-                not: { kind: rail }
-
-            draw:
-                text:
-                    font:
-                        fill: white
-                        family: Helvetica
-                        size: 11px
-
+            filter: { name: true }
             highway:
-                filter: { kind: highway }
+                filter: { kind: highway, $zoom: { min: 7 } }
                 draw:
                     text:
                         font:
+                            family: Helvetica
+                            fill: white
                             size: 12px
                             weight: bold
+            not_highway:
+                filter: { not: { kind: highway }, $zoom: { min: 13 } }
+                draw:
+                    text:
+                        font:
+                            family: Helvetica
+                            fill: white
+                            size: 11px
 
     buildings:
         data: { source: mapzen }
@@ -87,12 +79,10 @@ layers:
         draw:
             polygons:
                 order: 50
-                color: '#4d4d4d'
-
+                color: '#999'
         extruded:
             filter: { $zoom: { min: 15 } }
             draw:
                 polygons:
                     style: buildings
-                    color: '#999'
                     extrude: function () { return feature.height > 0 || $zoom >= 16; }

--- a/meta/example-scenes/README.md
+++ b/meta/example-scenes/README.md
@@ -1,0 +1,83 @@
+# example scenes cache
+
+This directory contains Node scripts for fetching and saving example scene files
+displayed in Tangram Play's "Open an example" modal.
+
+Most of the scene files come from https://github.com/tangrams/tangram-sandbox,
+but can be located anywhere. Previously, Tangram Play loaded scene files and
+image thumbnails from the Sandbox's Rawgit cache, but this created some
+noticeable problems: first, Rawgit (and GitHub itself) may occasionally go
+down, and secondly, the image files were not optimized, resulting in long
+loading times. (We were downloading 18MB of images when the examples modal
+we opened, and it could take ten seconds to load fully, even on a good Internet
+connection.)
+
+So we want to (a) remove the dependency on third-party, free & unsupported
+content delivery services, and (b) optimize the thumbnail images for display
+in Tangram Play. We can automate this instead of having to download and optimize
+images ourselves. Two scripts are provided here. One downloads scene files
+and stores them in Tangram Play, the other downloads screenshot images and
+converts them to thumbnails, optimizing for file size. These files become
+static resources that will be stored directly in this repository, and deployed
+along with Tangram Play
+
+These scripts are designed to run only when needed, (whenever we update the
+examples list) so it is not part of the build or deploy process. Project
+maintainers are expected to run these scripts manually. When scene files or
+thumbnail images are updated or created, commit the changes to the repository.
+Be sure to update Tangram Play's `examples.json` so that the correct images
+appear in the "Open an example" menu.
+
+An npm script is provided for convenience.
+
+```
+npm run examples
+```
+
+## sources
+
+One script exports an object whose keys are the filename to save to, and
+values are external URLs of the scene file or the screenshot image. Because this
+script runs rarely, and when needed, linking to Rawgit caches or GitHub URLs
+are acceptable here.
+
+When this script is run, all valid URLs will replace their destination files.
+URLs that are not valid for any reason (e.g. 404, 500 errors) are skipped with
+a warning. If you remove an entry or rename it, you will also have to remove
+the old destination files, scripts will not take care of that for you. This is
+because some examples may not have third-party sources so it will not delete
+anything that looks unfamiliar.
+
+## scene files
+
+This is pretty simple; it downloads and saves each scene file locally. Not all
+scene files need to be saved; if it's hosted on mapzen.com, we can retrieve if
+from its canonical source. (We might revisit this if we need offline-first
+Tangram Play.)
+
+You can run this script by itself with this npm script:
+
+```
+npm run examples:scenes
+```
+
+## thumbnail images
+
+To run this script, you will need a native installation of ImageMagick.
+On Mac OS X, you can use Homebrew:
+
+```
+brew install imagemagick
+```
+
+Each screenshot image is downloaded, resized, and cropped to the dimensions that
+Tangram Play expects (and at Retina resolution), optimized for file size and
+rendering, and saved to the `/data/scenes/thumbnails` path in this repository.
+
+You may edit this script update image dimensions.
+
+You can run this script by itself with this npm script:
+
+```
+npm run examples:thumbnails
+```

--- a/meta/example-scenes/cache-scenes.js
+++ b/meta/example-scenes/cache-scenes.js
@@ -1,0 +1,46 @@
+/**
+ * A node script for fetching and saving example scene files for Tangram Play
+ * locally. For more information, see README.md in this directory.
+ */
+'use strict';
+
+// Keep dependencies low, only use Node.js native modules
+const path = require('path');
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+
+const IMAGE_SOURCES = require('./sources');
+const WRITE_PATH = '../../data/scenes';
+
+for (let name in IMAGE_SOURCES) {
+    const url = IMAGE_SOURCES[name].scene;
+
+    // Not all scenes have urls to cache; move on to the next if that's the case
+    if (!url) {
+        continue;
+    }
+
+    const destination = path.resolve(__dirname, WRITE_PATH, name + '.yaml');
+
+    // Depending on the URL's protocol, Node either needs the `http` or `https`
+    // module.
+    const protocol = url.startsWith('https') ? https : http;
+
+    protocol.get(url, (response) => {
+        // Continuously update stream with data
+        let body = '';
+        response.on('data', function (data) {
+            body += data;
+        });
+        response.on('end', function () {
+            // Data reception is done, save it to destination
+            fs.writeFile(destination, body, (err) => {
+                if (err) {
+                    throw err;
+                }
+                console.log(`${destination} - done.`);
+            });
+        });
+    });
+}

--- a/meta/example-scenes/cache-thumbnails.js
+++ b/meta/example-scenes/cache-thumbnails.js
@@ -27,7 +27,7 @@
  *
  * Then run this script with node
  *
- *      node ./meta/make-scene-thumbnails.js
+ *      node ./meta/example-scenes/cache-thumbnails.js
  *
  * Can this be done in a shell script? Probably!
  */
@@ -39,41 +39,22 @@ const imagemin = require('imagemin');
 const imageminPngquant = require('imagemin-pngquant');
 const imageminGifsicle = require('imagemin-gifsicle');
 
+const IMAGE_SOURCES = require('./sources');
 const THUMBNAIL_WIDTH = 245;
 const THUMBNAIL_HEIGHT = 60;
 const RETINA_MULTIPLIER = 2;
-const WRITE_PATH = '../data/scenes/thumbnails';
-
-/* eslint-disable quote-props */
-const IMAGE_SOURCES = {
-    'default': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/default.png',
-    'grain': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/grain.png',
-    'grain-roads': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/grain-roads.png',
-    'grain-area': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/grain-area.png',
-    'refill': 'https://cloud.githubusercontent.com/assets/853051/11160181/87349950-8a1b-11e5-8559-5c6d95cb84d5.png',
-    'cinnabar': 'https://cloud.githubusercontent.com/assets/853051/11084429/f615a860-87ef-11e5-8ca9-6c46cec3534b.png',
-    'zinc': 'https://cloud.githubusercontent.com/assets/853051/11136794/c8c54190-8966-11e5-9017-b7f06d6841bb.png',
-    'gotham': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/gotham.png',
-    'blueprint': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/blueprint.png',
-    'tron': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/tron.png',
-    'matrix': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/matrix.png',
-    'ikeda': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/ikeda.png',
-    '9845c': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/9845C.png[0]', // Special case: force this to be a 1-frame png
-    'press': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/press.png',
-    'radar': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/radar.png',
-    'crosshatch': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/crosshatch.png',
-    'pericoli': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/pericoli.png',
-    'patterns': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/patterns.png',
-    'lego': 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/lego.png',
-    'walkabout': 'https://s3.amazonaws.com/static-prod.mapzen.com/resources/maps-page-hero/walkabout-style.png'
-};
-/* eslint-enable quote-props */
+const WRITE_PATH = '../../data/scenes/thumbnails';
 
 for (let name in IMAGE_SOURCES) {
-    const url = IMAGE_SOURCES[name];
+    const url = IMAGE_SOURCES[name].image;
+    const forcePNG = IMAGE_SOURCES[name].forcePNG || false;
     const destination = path.resolve(__dirname, WRITE_PATH);
 
-    gm(url)
+    // If we want to force an animated GIF to be a one-frame PNG, we fetch the
+    // url with a `[0]`
+    const fetchURL = forcePNG ? url + '[0]' : url;
+
+    gm(fetchURL)
         .format(function (err, value) {
             if (err) {
                 console.log(`Error: unable to determine format for ${url}: ${err}`);
@@ -81,10 +62,7 @@ for (let name in IMAGE_SOURCES) {
             }
 
             let ext = value.toLowerCase();
-            // Special hard-coded case for 9845c, which is a very subtle
-            // animation and results in an unnecessarily large 1MB gif, so force
-            // it to be PNG.
-            if (name === '9845c') {
+            if (forcePNG === true) {
                 ext = 'png';
             }
 

--- a/meta/example-scenes/cache-thumbnails.js
+++ b/meta/example-scenes/cache-thumbnails.js
@@ -1,24 +1,9 @@
 /**
  * A node script for making the thumbnails for scene files displayed in
- * Tangram Play's "Open an example" modal. The images are static resources
- * that will be stored directly in this repository, and deployed along with
- * Tangram Play, reducing its dependency on GitHub or RawGit to operate. This
- * is designed to run only when needed, so it is not part of the build or
- * deploy process.
+ * Tangram Play's "Open an example" modal. For more information, see
+ * README.md in this directory.
  *
- * This script provides an object whose keys are the filename to save to and
- * values that are an external URL where that image resides. Each URL is
- * downloaded, resized, and cropped to the dimensions that Tangram Play expects,
- * optimized for file size and rendering, and saved to the /data/scenes/thumbnails
- * path in this repository. When this script is run, all valid URLs that match
- * existing thumbnail images will replace them. If you remove a URL here, you
- * will also have to remove the thumbnail yourself, if you need to. URLs that
- * are not valid for any reason (e.g. 404, 500 errors) are skipped with a warning.
- *
- * You may edit this script to provide new image URL sources, or update image
- * dimensions. When images are updated or created, commit the changes to the
- * repository. Be sure to update Tangram Play's `examples.json` so that the
- * correct images appear in the "Open an example" menu.
+ * You may edit this script to update image dimensions.
  *
  * To run this script, you will need a native installation of ImageMagick.
  * On Mac OS X, you can use Homebrew:

--- a/meta/example-scenes/sources.js
+++ b/meta/example-scenes/sources.js
@@ -56,10 +56,12 @@ const IMAGE_SOURCES = {
         scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/matrix.yaml'
     },
     'ikeda': {
+        // Note that the original source is actually an animated GIF, despite the PNG extension
         image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/ikeda.png',
         scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/ikeda.yaml'
     },
     '9845c': {
+        // Note that the original source is actually an animated GIF, despite the PNG extension
         image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/9845C.png',
         forcePNG: true, // Special case: force this to be a 1-frame png
         scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/9845C.yaml'
@@ -69,6 +71,7 @@ const IMAGE_SOURCES = {
         scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/press.yaml'
     },
     'radar': {
+        // Note that the original source is actually an animated GIF, despite the PNG extension
         image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/radar.png',
         scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/radar.yaml'
     },

--- a/meta/example-scenes/sources.js
+++ b/meta/example-scenes/sources.js
@@ -1,0 +1,94 @@
+/**
+ * This exports URLs for YAML scene files and screenshot images for the example
+ * scenes that Tangram Play uses. Only files that are hosted on third-party
+ * remote services, like GitHub, Rawgit, or others, should be stored here.
+ * Scene files hosted on Mapzen servers do not need to be cached in this
+ * repository.
+ */
+
+/* eslint-disable quote-props */
+const IMAGE_SOURCES = {
+    'default': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/default.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/default.yaml'
+    },
+    'grain': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/grain.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/grain.yaml'
+    },
+    'grain-roads': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/grain-roads.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/grain-roads.yaml'
+    },
+    'grain-area': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/grain-area.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/grain-area.yaml'
+    },
+    // For the Mapzen house styles, we will obtain the YAML scene files from
+    // Mapzen's carto CDN. Do not store these locally.
+    'refill': {
+        image: 'https://cloud.githubusercontent.com/assets/853051/11160181/87349950-8a1b-11e5-8559-5c6d95cb84d5.png',
+        scene: null
+    },
+    'cinnabar': {
+        image: 'https://cloud.githubusercontent.com/assets/853051/11084429/f615a860-87ef-11e5-8ca9-6c46cec3534b.png',
+        scene: null
+    },
+    'zinc': {
+        image: 'https://cloud.githubusercontent.com/assets/853051/11136794/c8c54190-8966-11e5-9017-b7f06d6841bb.png',
+        scene: null
+    },
+    // End house styles
+    'gotham': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/gotham.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/gotham.yaml'
+    },
+    'blueprint': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/blueprint.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/blueprint.yaml'
+    },
+    'tron': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/tron.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/tron.yaml'
+    },
+    'matrix': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/matrix.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/matrix.yaml'
+    },
+    'ikeda': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/ikeda.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/ikeda.yaml'
+    },
+    '9845c': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/9845C.png',
+        forcePNG: true, // Special case: force this to be a 1-frame png
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/9845C.yaml'
+    },
+    'press': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/press.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/press.yaml'
+    },
+    'radar': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/radar.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/radar.yaml'
+    },
+    'crosshatch': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/crosshatch.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/crosshatch.yaml'
+    },
+    'pericoli': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/pericoli.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/pericoli.yaml'
+    },
+    'patterns': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/patterns.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/patterns.yaml'
+    },
+    'lego': {
+        image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/lego.png',
+        scene: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/lego.yaml'
+    }
+};
+/* eslint-enable quote-props */
+
+module.exports = IMAGE_SOURCES;

--- a/meta/example-scenes/sources.js
+++ b/meta/example-scenes/sources.js
@@ -38,6 +38,10 @@ const IMAGE_SOURCES = {
         image: 'https://cloud.githubusercontent.com/assets/853051/11136794/c8c54190-8966-11e5-9017-b7f06d6841bb.png',
         scene: null
     },
+    'walkabout': {
+        image: 'https://s3.amazonaws.com/static-prod.mapzen.com/resources/maps-page-hero/walkabout-style.png',
+        scene: null
+    },
     // End house styles
     'gotham': {
         image: 'https://cdn.rawgit.com/tangrams/tangram-sandbox/1d60a85ed384150d8a98c26fa30f5a4123c1224f/styles/gotham.png',

--- a/meta/make-scene-thumbnails.js
+++ b/meta/make-scene-thumbnails.js
@@ -76,7 +76,7 @@ for (let name in IMAGE_SOURCES) {
     gm(url)
         .format(function (err, value) {
             if (err) {
-                console.log(`Error: unable to determine format for ${url}`);
+                console.log(`Error: unable to determine format for ${url}: ${err}`);
                 return;
             }
 
@@ -96,6 +96,7 @@ for (let name in IMAGE_SOURCES) {
                 .resize(width, height, '^')
                 .gravity('Center')
                 .extent(width, height)
+                .interlace('Line')
                 .write(filename, function (err) {
                     if (err) {
                         console.log(`Error writing ${filename}:\n ${err}`);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint-css": "stylelint src/css/*.css",
     "karma": "./node_modules/karma/bin/karma start",
     "postinstall": "modernizr -c modernizr-config.json -d build/js; gulp build",
-    "make-thumbnails": "node meta/make-scene-thumbnails.js"
+    "examples": "npm run examples:thumbnails && npm run examples:scenes",
+    "examples:thumbnails": "node meta/example-scenes/cache-thumbnails.js",
+    "examples:scenes": "node meta/example-scenes/cache-scenes.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "lint-css": "stylelint src/css/*.css",
     "karma": "./node_modules/karma/bin/karma start",
     "postinstall": "modernizr -c modernizr-config.json -d build/js; gulp build",
-    "examples": "npm run examples:thumbnails && npm run examples:scenes",
-    "examples:thumbnails": "node meta/example-scenes/cache-thumbnails.js",
-    "examples:scenes": "node meta/example-scenes/cache-scenes.js"
+    "examples": "npm run examples:scenes && npm run examples:thumbnails",
+    "examples:scenes": "node meta/example-scenes/cache-scenes.js",
+    "examples:thumbnails": "node meta/example-scenes/cache-thumbnails.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Following up from #434! This PR adds caching scene file YAMLs in the Tangram Play repository and unifies it with the earlier work for adding optimized thumbnails.