### PR TITLE
Add support for highlighting multiple ranges of lines.

### DIFF
--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -69,6 +69,13 @@ editor.on('gutterClick', function (cm, line, gutter, event) {
 // Editor operations, such as cut, paste, delete, or inserts, can mutate
 // highlighted lines. This will make sure the query string remains updated.
 editor.on('changes', function (cm, changes) {
+    // Small performance tweak: if there's just one change on one line,
+    // don't bother updating the query string, which must check the highlight
+    // state on all lines
+    if (changes.length === 1 && changes[0].removed.length === 1 && changes[0].text.length === 1) {
+        return;
+    }
+
     updateLinesQueryString();
 });
 

--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -6,7 +6,6 @@ const HIGHLIGHT_CLASS = 'editor-highlight';
 
 let anchorLine;
 let targetLine;
-let manuallyHighlighted = false;
 
 editor.on('gutterClick', function (cm, line, gutter, event) {
     // Do work when the click occurs for the left (or main) mouse button only
@@ -42,7 +41,6 @@ editor.on('gutterClick', function (cm, line, gutter, event) {
 
         // Remember state of how this happened
         targetLine = line;
-        manuallyHighlighted = true;
     }
     // If shift key is not pressed or there is not a previously selected line
     // (which you need to do the whole range) then select one line.
@@ -58,7 +56,6 @@ editor.on('gutterClick', function (cm, line, gutter, event) {
         else {
             highlightLine(cm.getDoc(), line);
             anchorLine = line;
-            manuallyHighlighted = true;
         }
 
         // Reset
@@ -250,21 +247,12 @@ export function highlightBlock (node) {
     // Reset
     anchorLine = undefined;
     targetLine = undefined;
-    manuallyHighlighted = false;
 }
 
 /**
  * Removes highlights from all lines in the document.
- *
- * @param {Boolean} defer - Optional. Default is false. If `true`, then this
- *          function does not unhighlight any lines if the current highlighting
- *          was created by a user clicking on the gutters.
  */
-export function unhighlightAll ({ defer = false } = {}) {
-    if (defer === true) {
-        return;
-    }
-
+function unhighlightAll () {
     const doc = editor.getDoc();
 
     for (let i = 0, j = doc.lineCount(); i <= j; i++) {

--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -260,11 +260,9 @@ export function highlightBlock (node) {
  * @param {Boolean} defer - Optional. Default is false. If `true`, then this
  *          function does not unhighlight any lines if the current highlighting
  *          was created by a user clicking on the gutters.
- * @param {Boolean} updateQueryString - Optional. Default is true. If `false`,
- *          then the query string is not blanked after unhighlighting lines.
  */
 export function unhighlightAll ({ defer = false } = {}) {
-    if (defer === true && manuallyHighlighted === true) {
+    if (defer === true) {
         return;
     }
 

--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -69,6 +69,12 @@ editor.on('gutterClick', function (cm, line, gutter, event) {
     updateLinesQueryString();
 });
 
+// Editor operations, such as cut, paste, delete, or inserts, can mutate
+// highlighted lines. This will make sure the query string remains updated.
+editor.on('changes', function (cm, changes) {
+    updateLinesQueryString();
+});
+
 /**
  * Highlights a given line in the document.
  *
@@ -297,7 +303,7 @@ export function getAllHighlightedLines () {
  * document.
  *
  */
-function updateLinesQueryString () {
+export function updateLinesQueryString () {
     const locationPrefix = window.location.pathname;
     const queryObj = getQueryStringObject();
     const allHighlightedLines = getAllHighlightedLines();

--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -107,8 +107,7 @@ function unhighlightLine (doc, line) {
  *          and `false` if a line was unhighlighted.
  */
 function toggleHighlightLine (doc, line) {
-    const lineInfo = editor.lineInfo(line);
-    if (lineInfo.bgClass === HIGHLIGHT_CLASS) {
+    if (isLineHighlighted(line)) {
         unhighlightLine(doc, line);
         return false;
     }
@@ -274,6 +273,25 @@ export function unhighlightAll ({ defer = false } = {}) {
 }
 
 /**
+ * Returns true if a line is highlighted. It does this by checking whether the
+ * line number has the highlight class attached to it. Note that other background
+ * classes may exist (e.g. for active lines).
+ *
+ * @param {Number} line - the line number to check.
+ * @returns {Boolean}
+ */
+function isLineHighlighted (line) {
+    const lineInfo = editor.lineInfo(line);
+
+    // .bgClass may be null
+    if (!lineInfo.bgClass) {
+        return false;
+    }
+
+    return (lineInfo.bgClass.indexOf(HIGHLIGHT_CLASS) >= 0);
+}
+
+/**
  * Gets a string representation of all highlighted lines in the editor.
  * This looks at the editor itself, so it's guaranteed to be the current state
  * of the editor.
@@ -281,12 +299,11 @@ export function unhighlightAll ({ defer = false } = {}) {
  * @returns {String} linenumbers - in the format of '2-5,10,18-20', as
  *          returned by getLineNumberString() function
  */
-export function getAllHighlightedLines () {
+function getAllHighlightedLines () {
     const lineNumbers = [];
 
     for (let i = 0, j = editor.getDoc().lineCount(); i < j; i++) {
-        const lineInfo = editor.lineInfo(i);
-        if (lineInfo.bgClass === HIGHLIGHT_CLASS) {
+        if (isLineHighlighted(i)) {
             lineNumbers.push(i);
         }
     }

--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -145,6 +145,42 @@ export function highlightLines (from, to, clear = true) {
 }
 
 /**
+ * Highlights lines, given a comma delimited set of line numbers or ranges of
+ * line numbers. Expects a string that would have been formed with
+ * getLineNumberString(). The following are valid strings:
+ *
+ *      '6'
+ *      '6-10'
+ *      '6-10,12-30'
+ *      '6-10,12-30,45,60-12'
+ *
+ * Note that the ranges are assumed to be in sequential order, and line numbers
+ * start from 1 instead of 0. The first linenumber or range will get jumped to.
+ *
+ * @param {String} lines - Required. A human-readable sequence of lines and
+ *          line ranges to highlight.
+ */
+export function highlightRanges (lines) {
+    const ranges = lines.split(',');
+
+    for (let i = 0, j = ranges.length; i < j; i++) {
+        const lines = ranges[i].split('-');
+
+        // Lines are zero-indexed in CodeMirror, so subtract 1 from it.
+        // Just in case, the return value is clamped to a minimum value of 0.
+        const startLine = Math.max(Number(lines[0]) - 1, 0);
+        const endLine = Math.max(Number(lines[1]) - 1, 0);
+
+        // Only jump to the first range given.
+        if (i === 0) {
+            jumpToLine(editor, startLine);
+        }
+
+        highlightLines(startLine, endLine, false);
+    }
+}
+
+/**
  * Given a node, find all the lines that are part of that entire block, and then
  * applies a highlight class to each of those lines.
  * TODO: This can still be pretty buggy because `stateAfter` is still not

--- a/src/js/map/inspection.js
+++ b/src/js/map/inspection.js
@@ -3,7 +3,7 @@ import L from 'leaflet';
 import { map, tangramLayer } from './map';
 import { emptyDOMElement } from '../tools/helpers';
 import TangramPlay from '../tangram-play';
-import { highlightBlock, unhighlightAll } from '../editor/highlight';
+import { highlightBlock } from '../editor/highlight';
 
 const EMPTY_SELECTION_KIND_LABEL = 'Unknown feature';
 const EMPTY_SELECTION_NAME_LABEL = '(unnamed)';
@@ -404,9 +404,6 @@ class TangramInspectionPopup {
             // popup class to provide the Y-position transform.
             event.popup._container.style.transform = null;
             isPopupOpen = false;
-
-            // Remove highlights. Defers to user-generated highlighting, if any.
-            unhighlightAll({ defer: true });
 
             // Clean up events from the map listeners
             map.off('popupclose', onPopupClose);

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -74,15 +74,23 @@ class TangramPlay {
                 // Highlight lines if requested by the query string.
                 let lines = query.lines;
                 if (lines) {
-                    lines = lines.split('-');
+                    const ranges = lines.split(',');
 
-                    // Lines are zero-indexed in CodeMirror, so subtract 1 from it.
-                    // Just in case, the return value is clamped to a minimum value of 0.
-                    const startLine = Math.max(Number(lines[0]) - 1, 0);
-                    const endLine = Math.max(Number(lines[1]) - 1, 0);
+                    for (let i = 0, j = ranges.length; i < j; i++) {
+                        const lines = ranges[i].split('-');
 
-                    jumpToLine(editor, startLine);
-                    highlightLines(startLine, endLine, false);
+                        // Lines are zero-indexed in CodeMirror, so subtract 1 from it.
+                        // Just in case, the return value is clamped to a minimum value of 0.
+                        const startLine = Math.max(Number(lines[0]) - 1, 0);
+                        const endLine = Math.max(Number(lines[1]) - 1, 0);
+
+                        // Only jump to the first range given.
+                        if (i === 0) {
+                            jumpToLine(editor, startLine);
+                        }
+
+                        highlightLines(startLine, endLine, false);
+                    }
                 }
 
                 // Add widgets marks.

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -32,7 +32,7 @@ import { getQueryStringObject, serializeToQueryString, prependProtocolToUrl } fr
 import { isGistURL, getSceneURLFromGistAPI } from './tools/gist-url';
 import { debounce, createObjectURL } from './tools/common';
 import { parseYamlString } from './editor/codemirror/yaml-tangram';
-import { highlightRanges } from './editor/highlight';
+import { highlightRanges, updateLinesQueryString } from './editor/highlight';
 
 // Import UI elements
 import { initDivider } from './ui/divider';
@@ -74,6 +74,7 @@ class TangramPlay {
                 let lines = query.lines;
                 if (lines) {
                     highlightRanges(lines);
+                    updateLinesQueryString();
                 }
 
                 // Add widgets marks.

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -31,9 +31,8 @@ import { subscribeMixin } from './tools/mixin';
 import { getQueryStringObject, serializeToQueryString, prependProtocolToUrl } from './tools/helpers';
 import { isGistURL, getSceneURLFromGistAPI } from './tools/gist-url';
 import { debounce, createObjectURL } from './tools/common';
-import { jumpToLine } from './editor/codemirror/tools';
 import { parseYamlString } from './editor/codemirror/yaml-tangram';
-import { highlightLines } from './editor/highlight';
+import { highlightRanges } from './editor/highlight';
 
 // Import UI elements
 import { initDivider } from './ui/divider';
@@ -74,23 +73,7 @@ class TangramPlay {
                 // Highlight lines if requested by the query string.
                 let lines = query.lines;
                 if (lines) {
-                    const ranges = lines.split(',');
-
-                    for (let i = 0, j = ranges.length; i < j; i++) {
-                        const lines = ranges[i].split('-');
-
-                        // Lines are zero-indexed in CodeMirror, so subtract 1 from it.
-                        // Just in case, the return value is clamped to a minimum value of 0.
-                        const startLine = Math.max(Number(lines[0]) - 1, 0);
-                        const endLine = Math.max(Number(lines[1]) - 1, 0);
-
-                        // Only jump to the first range given.
-                        if (i === 0) {
-                            jumpToLine(editor, startLine);
-                        }
-
-                        highlightLines(startLine, endLine, false);
-                    }
+                    highlightRanges(lines);
                 }
 
                 // Add widgets marks.


### PR DESCRIPTION
Resolves #388.

Functional, but there may still be room for improvement. There are not many role models of exemplary line highlighting behavior in other text editors -- neither Sublime Text anything based on stock CodeMirror editor has it. Atom does it, and the implementation is quite good, with the noticeable exception that once you've shift-clicked a range of lines, you can't command-click within it to deselect an individual line. I've also picked up some influence from the way you can select multiple files in Mac OSX's Finder.

Included in this PR:
- You can now Command-Click on individual line numbers to add highlighted lines. Line numbers do not need to be adjacent. Command-clicking lines that are already highlighted will unhighlight them.
- You can now Shift-click multiple ranges of lines. This is done by command-clicking a new line to act as the the new anchor point, and shift-clicking to select the new range. The "edge case" here is what happens if you shift-click a new range that intersects or overlaps previously highlighted ranges. In Atom, the ranges will be joined together, whereas in Finder, separate ranges that intersect will be cleared. Tangram Play will deal with this in a manner similar to Atom's behavior.
- The `?lines=` URL query parameter accepts ranges, e.g. `?lines=12-24,120-136,145,199-201`. This URL parameter now also updates automatically when text editor operations, like cut, paste, insert, deletes change line numbers. Note that URL encoding makes the `,` commas into `%2C`, which looks less user-friendly but is not avoidable without special-casing how query parameters are processed. You can still write URLs with the user-friendly commas, though.

This should be good for tutorials and examples linking! cc @irealva @patriciogonzalezvivo 