### PR TITLE
Fix inner-mode tokenization for single-line functions and globals

### DIFF
--- a/src/js/editor/codemirror/yaml-tangram.js
+++ b/src/js/editor/codemirror/yaml-tangram.js
@@ -4,8 +4,6 @@ import 'codemirror/mode/yaml/yaml.js';
 import './glsl-tangram';
 import { attachWidgetMarkConstructorsToDocumentState } from './widgets';
 
-import { tangramScene } from '../../map/map';
-
 const ADDRESS_KEY_DELIMITER = ':';
 
 // GET public functions
@@ -135,25 +133,19 @@ export function isFilterBlock (address) {
  * JavaScript values must be a single function. This makes detection easy:
  * See if the beginning of the string starts with a valid function declaration.
  *
- * @param {Tangram.scene} tangramScene - scene object from Tangram
- * @param {string} address - the address of the key-value pair
+ * @param {string} value - the first line of key-value YAML node to check
+ *          if it looks like a Javascript function
  * @return {Boolean} bool - `true` if value appears to be a JavaScript function
+ * @todo This returns false if any parameters are passed to a function.
  */
-function isContentJS (tangramScene, address) {
-    if (tangramScene && tangramScene.config) {
-        const content = getAddressSceneContent(tangramScene, address);
+function isContentJS (value) {
+    // Regex pattern. Content can begin with any amount of whitespace.
+    // Where whitespace is allowed, it can be any amount of whitespace.
+    // Content may begin with a pipe "|" character for YAML multi-line
+    // strings. Next, test if "function () {" (with opening brace).
+    const re = /^\s*\|?\s*function\s*\(\s*\)\s*\{/m;
 
-        // Regex pattern. Content can begin with any amount of whitespace.
-        // Where whitespace is allowed, it can be any amount of whitespace.
-        // Content may begin with a pipe "|" character for YAML multi-line
-        // strings. Next, test if "function () {" (with opening brace).
-        const re = /^\s*\|?\s*function\s*\(\s*\)\s*\{/m;
-
-        return re.test(content);
-    }
-    else {
-        return false;
-    }
+    return re.test(value);
 }
 
 function isAfterKey (str, pos) {
@@ -381,6 +373,7 @@ CodeMirror.defineMode('yaml-tangram', function (config, parserConfig) {
                 innerMode: null,
                 innerState: null,
                 shouldChangeInnerMode: false,
+                singleLineInnerMode: false,
                 parentBlockIndent: 0
             });
         },
@@ -461,7 +454,7 @@ CodeMirror.defineMode('yaml-tangram', function (config, parserConfig) {
                     if (isShader(address)) {
                         state.innerMode = glslMode;
                     }
-                    else if (isContentJS(tangramScene, address)) {
+                    else if (isContentJS(state.string)) {
                         state.innerMode = jsMode;
                     }
 
@@ -483,8 +476,11 @@ CodeMirror.defineMode('yaml-tangram', function (config, parserConfig) {
                 else if (isShader(address)) {
                     state.innerMode = glslMode;
                 }
-                else if (isContentJS(tangramScene, address)) {
+                // This inner mode is assumed to be on one line only, so
+                // we need to make them active only for the current line.
+                else if (isContentJS(value)) {
                     state.innerMode = jsMode;
+                    state.singleLineInnerMode = true;
                 }
             }
 
@@ -498,6 +494,18 @@ CodeMirror.defineMode('yaml-tangram', function (config, parserConfig) {
             }
             else {
                 token = yamlMode.token(stream, state);
+            }
+
+            // Actions to perform at the end of the stream.
+            if (stream.eol()) {
+                // If an inner mode is activated, but for one line only, then
+                // we want to reset the innermode and inner state at the end
+                // of the line.
+                if (state.singleLineInnerMode === true) {
+                    state.innerMode = null;
+                    state.innerState = null;
+                    state.singleLineInnerMode = false;
+                }
             }
 
             return token;


### PR DESCRIPTION
This improves YAML parsing so that JavaScript functions that are one-line values are tokenized (highlighted) accordingly. Furthermore, by keeping the JavaScript check within the editor content (and not by looking at the Tangram scene config) we fix some race condition bugs (YAML parsing at the the time of start-up may occur before the scene config object is prepared by Tangram), and most notably, resolves an issue where a global reference to a JavaScript function causes YAML editor content to be incorrectly tokenized as JavaScript (resolving issue #449).
