### PR TITLE
Enable .jsx extensions in codebase

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var browserSync = require('browser-sync');
 
 var paths = {
     styles: 'src/css/**/*.css',
-    scripts: 'src/js/**/*.js',
+    scripts: 'src/js/**/*.{js,jsx}',
     app: 'index.html'
 };
 
@@ -69,6 +69,7 @@ gulp.task('js', function () {
     var bundle = browserify({
         entries: 'src/js/tangram-play.js',
         debug: true,
+        extensions: ['.jsx'],
         transform: [
             babelify.configure({ presets: ['es2015', 'react'] }),
             shim,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "gulp serve",
     "test": "npm run lint --silent && npm run karma --silent",
     "lint": "npm run lint-js --silent && npm run lint-css --silent",
-    "lint-js": "eslint *.js src/ test/",
+    "lint-js": "eslint *.js src/ test/ --ext .js,.jsx",
     "lint-css": "stylelint src/css/*.css",
     "karma": "./node_modules/karma/bin/karma start",
     "postinstall": "modernizr -c modernizr-config.json -d build/js; gulp build",


### PR DESCRIPTION
Small PR, which adds the following in preparation of naming files with a `.jsx` extension (see #458).

- Browserify / Babel will `import` files that do not explicitly specify the `.jsx` extension
- Gulp watches `.jsx` files and will rebundle if those are changed
- ESLint lints `.jsx` files too.