### PR TITLE
Refactor map event listeners for performance. Resolves #469, partially

### DIFF
--- a/src/css/_map-panel.react.css
+++ b/src/css/_map-panel.react.css
@@ -91,11 +91,16 @@
 }
 
 /* Style for button groups */
+.map-panel-zoom-container {
+    display: flex;
+}
+
 .map-panel-zoom {
     width: 38px;
     margin-right: 4px;
     font-size: 12px;
     text-align: center;
+    line-height: 38px;
 }
 
 .buttons-plusminus {

--- a/src/js/components/MapPanelBookmarks.js
+++ b/src/js/components/MapPanelBookmarks.js
@@ -32,6 +32,7 @@ export default class MapPanelBookmarks extends React.Component {
         };
 
         this.shouldDropdownToggle = this.shouldDropdownToggle.bind(this);
+        this.bookmarksClearedCallback = this.bookmarksClearedCallback.bind(this);
     }
 
     componentDidMount () {
@@ -59,11 +60,11 @@ export default class MapPanelBookmarks extends React.Component {
     /**
      * Fires when a user clicks on a bookmark from bookmark list.
      * Causes map and search panel to re-render to go to the location on the bookmark
-     * @param eventKey - each bookmark in the bookmark list identified by a unique
+     * @param key - each bookmark in the bookmark list identified by a unique
      *      key
      */
-    onClickGoToBookmark (eventKey) {
-        const bookmark = this.state.bookmarks[eventKey];
+    onClickGoToBookmark (key) {
+        const bookmark = this.state.bookmarks[key];
 
         const coordinates = { lat: bookmark.lat, lng: bookmark.lng };
         const zoom = bookmark.zoom;
@@ -78,11 +79,11 @@ export default class MapPanelBookmarks extends React.Component {
 
     /**
      * Delete a single bookmark
-     * @param eventKey - the bookmark index to delete
+     * @param key - the bookmark index to delete
      */
-    onClickDeleteSingleBookmark (eventKey) {
+    onClickDeleteSingleBookmark (key) {
         this.overrideBookmarkClose = true; // We want to keep the dropdown open
-        bookmarks.deleteBookmark(eventKey);
+        bookmarks.deleteBookmark(key);
     }
 
     /**
@@ -157,6 +158,9 @@ export default class MapPanelBookmarks extends React.Component {
                     noCaret
                     pullRight
                     className='map-panel-bookmark-button'
+                    // The prop 'id' is required to make 'Dropdown' accessible
+                    // for users using assistive technologies such as screen readers
+                    id='map-panel-bookmark-button'
                     open={this.shouldDropdownToggle()}
                     onToggle={this.shouldDropdownToggle}
                 >
@@ -182,7 +186,6 @@ export default class MapPanelBookmarks extends React.Component {
                                     <MenuItem key={i}>
                                         <div
                                             className='bookmark-dropdown-info'
-                                            eventKey={i}
                                             onClick={() => this.onClickGoToBookmark(i)}
                                         >
                                             <div className='bookmark-dropdown-icon'>
@@ -198,7 +201,6 @@ export default class MapPanelBookmarks extends React.Component {
                                         </div>
                                         <div
                                             className='bookmark-dropdown-delete'
-                                            eventKey={i}
                                             onClick={() => this.onClickDeleteSingleBookmark(i)}
                                         >
                                             <Icon type={'bt-times'} />

--- a/src/js/components/MapPanelBookmarks.js
+++ b/src/js/components/MapPanelBookmarks.js
@@ -1,0 +1,193 @@
+import React from 'react';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
+import DropdownButton from 'react-bootstrap/lib/DropdownButton';
+import MenuItem from 'react-bootstrap/lib/MenuItem';
+import Icon from './icon.react';
+
+import bookmarks from '../map/bookmarks';
+import { map } from '../map/map';
+import Modal from '../modals/modal';
+// Required event dispatch and subscription for now while parts of app are React components and others are not
+import { EventEmitter } from './event-emitter';
+
+/**
+ * Represents the search bar and bookmarks button on the map panel
+ */
+export default class MapPanelBookmarks extends React.Component {
+    /**
+     * Used to setup the state of the component. Regular ES6 classes do not
+     * automatically bind 'this' to the instance, therefore this is the best
+     * place to bind event handlers
+     *
+     * @param props - parameters passed from the parent
+     */
+    constructor (props) {
+        super(props);
+
+        // Most of the time we don't want to override the bookmark button toggle function
+        this.overrideBookmarkClose = false;
+
+        this.state = {
+            bookmarks: this._updateBookmarks() // Stores all bookmarks
+        };
+
+        this._shouldDropdownToggle = this._shouldDropdownToggle.bind(this);
+    }
+
+    componentDidMount () {
+        // Need a notification when all bookmarks are cleared succesfully in order to re-render list
+        EventEmitter.subscribe('bookmarks:clear', data => { this._bookmarkCallback(); });
+    }
+
+    /**
+     * Official React lifecycle method
+     * Invoked immediately after the component's updates are flushed to the DOM
+     * Using a ref to the DOM element overlay tooltip on top of the dropdown button
+     * to make sure its closed after user clicks on a bookmark
+     */
+    componentDidUpdate (prevProps, prevState) {
+        this.refs.culpritOverlay.hide();
+        this.overrideBookmarkClose = false;
+    }
+
+    /**
+     * Fires when a user clicks on a bookmark from bookmark list.
+     * Causes map and search panel to re-render to go to the location on the bookmark
+     * @param eventKey - each bookmark in the bookmark list identified by a unique
+     *      key
+     */
+    _clickGoToBookmark (eventKey) {
+        let bookmarks = this.state.bookmarks;
+        let bookmark = bookmarks[eventKey];
+
+        const coordinates = { lat: bookmark.lat, lng: bookmark.lng };
+        const zoom = bookmark.zoom;
+
+        if (!coordinates || !zoom) {
+            return;
+        }
+
+        map.setView(coordinates, zoom);
+        EventEmitter.dispatch('bookmarks:active');
+    }
+
+    /**
+     * Delete a single bookmark
+     * @param eventKey - the bookmark index to delete
+     */
+    _clickDeleteSingleBookmark (eventKey) {
+        this.overrideBookmarkClose = true; // We want to keep the dropdown open
+        bookmarks.deleteBookmark(eventKey);
+    }
+
+    /**
+     * Callback called when dropdown button wants to change state from open to closed
+     * @param isOpen - state that dropdown wants to render to. Either true or false
+     */
+    _shouldDropdownToggle (isOpen) {
+        if (this.overrideBookmarkClose) {
+            return true;
+        }
+        else {
+            return isOpen;
+        }
+    }
+
+    /**
+     * Delete all bookmarks
+     */
+    _clickDeleteBookmarks () {
+        const modal = new Modal('Are you sure you want to clear your bookmarks? This cannot be undone.', bookmarks.clearData);
+        modal.show();
+    }
+
+    /**
+     * Callback issued from 'bookmarks' object in order to update the panel UI.
+     * Causes a re-render of the bookmarks list
+     */
+    _bookmarkCallback () {
+        this.setState({ bookmarks: this._updateBookmarks() });
+        this.setState({ bookmarkActive: '' });
+    }
+
+    /**
+     * Fetches current bookmarks from 'bookmarks' object a causes re-render of
+     * bookmarks list.
+     */
+    _updateBookmarks () {
+        let newBookmarks = [];
+        let bookmarkList = bookmarks.readData().data;
+
+        for (let i = 0; i < bookmarkList.length; i++) {
+            const bookmark = bookmarkList[i];
+            let fractionalZoom = Math.floor(bookmark.zoom * 10) / 10;
+
+            newBookmarks.push({
+                id: i,
+                label: bookmark.label,
+                lat: bookmark.lat.toFixed(4),
+                lng: bookmark.lng.toFixed(4),
+                zoom: fractionalZoom.toFixed(1),
+                onClick: this._clickGoToBookmark.bind(this),
+                active: ''
+            });
+        }
+
+        return newBookmarks;
+    }
+
+    /**
+     * Official React lifecycle method
+     * Called every time state or props are changed
+     */
+    render () {
+        return (
+            <OverlayTrigger rootClose ref='culpritOverlay' placement='bottom' overlay={<Tooltip id='tooltip-bookmark'>{'Bookmarks'}</Tooltip>}>
+                <DropdownButton title={<Icon type={'bt-bookmark'} />} bsStyle='default' noCaret pullRight className='map-panel-bookmark-button' id='map-panel-bookmark-button' open={this._shouldDropdownToggle()} onToggle={this._shouldDropdownToggle}>
+                    {/* Defining an immediately-invoked function expression inside JSX to decide whether to render full bookmark list or not */}
+                    {(() => {
+                        let bookmarkDropdownList;
+
+                        // If no bookmarks, then display a no bookmarks message
+                        if (this.state.bookmarks.length === 0) {
+                            bookmarkDropdownList =
+                                <MenuItem key='none' className='bookmark-dropdown-center'>
+                                    <div>No bookmarks yet!</div>
+                                </MenuItem>;
+                        }
+                        // If there are bookmarks
+                        else {
+                            // Create the bookmarks list
+                            let list =
+                                this.state.bookmarks.map((result, i) => {
+                                    return <MenuItem key={i}>
+                                                <div className='bookmark-dropdown-info' eventKey={i} onClick={() => this._clickGoToBookmark(i)} >
+                                                    <div className='bookmark-dropdown-icon'><Icon type={'bt-map-marker'} /></div>
+                                                    <div>{result.label}<br />
+                                                        <span className='bookmark-dropdown-text'>{result.lat}, {result.lng}, z{result.zoom}</span>
+                                                    </div>
+                                                </div>
+                                                <div className='bookmark-dropdown-delete' eventKey={i} onClick={() => this._clickDeleteSingleBookmark(i)}>
+                                                    <Icon type={'bt-times'} />
+                                                </div>
+                                            </MenuItem>;
+                                });
+
+                            // Add a delete button at the end
+                            let deletebutton =
+                                <MenuItem key='delete' onSelect={this._clickDeleteBookmarks} className='bookmark-dropdown-center clear-bookmarks'>
+                                    <div>Clear bookmarks</div>
+                                </MenuItem>;
+
+                            // In React we have to use arrays if we want to concatenate two JSX fragments
+                            bookmarkDropdownList = [list, deletebutton];
+                        }
+
+                        return bookmarkDropdownList;
+                    })()}
+                </DropdownButton>
+            </OverlayTrigger>
+        );
+    }
+}

--- a/src/js/components/MapPanelLocationBar.jsx
+++ b/src/js/components/MapPanelLocationBar.jsx
@@ -180,7 +180,6 @@ export default class MapPanelLocationBar extends React.Component {
     onClickSave () {
         const data = this.getCurrentMapViewData();
         if (bookmarks.saveBookmark(data)) {
-            EventEmitter.dispatch('bookmarks:updated');
             this.setState({
                 bookmarkActive: 'active-fill'
             });

--- a/src/js/components/MapPanelLocationBar.jsx
+++ b/src/js/components/MapPanelLocationBar.jsx
@@ -30,13 +30,13 @@ export default class MapPanelLocationBar extends React.Component {
         super(props);
 
         const mapCenter = map.getCenter();
-
-        this.latlngLabelPrecision = 4;
+        const latlngLabelPrecision = 4;
 
         this.state = {
+            latlngLabelPrecision: latlngLabelPrecision,
             latlng: {
-                lat: mapCenter.lat.toFixed(this.latlngLabelPrecision),
-                lng: mapCenter.lng.toFixed(this.latlngLabelPrecision)
+                lat: mapCenter.lat.toFixed(latlngLabelPrecision),
+                lng: mapCenter.lng.toFixed(latlngLabelPrecision)
             }, // Represents lat lng of current position of the map
             value: '', // Represents text in the search bar
             placeholder: '', // Represents placeholder of the search bar
@@ -155,16 +155,21 @@ export default class MapPanelLocationBar extends React.Component {
         // based on the available screen width
         const mapcontainer = document.getElementById('map-container');
         const width = mapcontainer.offsetWidth;
+        let latlngLabelPrecision;
 
         if (width < 600) {
-            this.latlngLabelPrecision = 2;
+            latlngLabelPrecision = 2;
         }
         else if (width < 800) {
-            this.latlngLabelPrecision = 3;
+            latlngLabelPrecision = 3;
         }
         else {
-            this.latlngLabelPrecision = 4;
+            latlngLabelPrecision = 4;
         }
+
+        this.setState({
+            latlngLabelPrecision: latlngLabelPrecision
+        });
     }
 
     /** Bookmark functionality **/
@@ -343,8 +348,8 @@ export default class MapPanelLocationBar extends React.Component {
         };
 
         const latlng = {
-            lat: parseFloat(this.state.latlng.lat).toFixed(this.latlngLabelPrecision),
-            lng: parseFloat(this.state.latlng.lng).toFixed(this.latlngLabelPrecision)
+            lat: parseFloat(this.state.latlng.lat).toFixed(this.state.latlngLabelPrecision),
+            lng: parseFloat(this.state.latlng.lng).toFixed(this.state.latlngLabelPrecision)
         };
 
         return (

--- a/src/js/components/MapPanelZoom.jsx
+++ b/src/js/components/MapPanelZoom.jsx
@@ -4,8 +4,8 @@ import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import Icon from './icon.react';
+import MapPanelZoomIndicator from './MapPanelZoomIndicator';
 import { map } from '../map/map';
-import { EventEmitter } from './event-emitter';
 
 export default class MapPanelZoom extends React.Component {
     /**
@@ -24,19 +24,6 @@ export default class MapPanelZoom extends React.Component {
 
         this.onClickZoomIn = this.onClickZoomIn.bind(this);
         this.onClickZoomOut = this.onClickZoomOut.bind(this);
-        this.setZoomLabel = this.setZoomLabel.bind(this);
-    }
-
-    /**
-     * Official React lifecycle method
-     * Invoked once immediately after the initial rendering occurs.
-     * Temporary requirement is to subscribe to events from map becuase it is
-     * not a React component
-     */
-    componentDidMount () {
-        // Need to subscribe to map zooming events so that our React component
-        // plays nice with the non-React map
-        EventEmitter.subscribe('zoomend', data => { this.setZoomLabel(); });
     }
 
     /** Zoom functionality **/
@@ -46,7 +33,7 @@ export default class MapPanelZoom extends React.Component {
      */
     onClickZoomIn () {
         map.zoomIn(1, { animate: true });
-        this.setZoomLabel();
+        this.setState({ zoom: map.getZoom() });
     }
 
     /**
@@ -54,22 +41,13 @@ export default class MapPanelZoom extends React.Component {
      */
     onClickZoomOut () {
         map.zoomOut(1, { animate: true });
-        this.setZoomLabel();
-    }
-
-    /**
-     * Zoom into the map when user click ZoomOut button
-     */
-    setZoomLabel () {
-        const currentZoom = map.getZoom();
-        const fractionalNumber = Math.floor(currentZoom * 10) / 10;
-        this.setState({ zoom: Number.parseFloat(fractionalNumber).toFixed(1) });
+        this.setState({ zoom: map.getZoom() });
     }
 
     render () {
         return (
             <div className='map-panel-zoom-container'>
-                <div className='map-panel-zoom'>z{this.state.zoom}</div>
+                <MapPanelZoomIndicator zoom={this.state.zoom} />
 
                 {/* Zoom buttons */}
                 <ButtonGroup className='buttons-plusminus'>

--- a/src/js/components/MapPanelZoom.jsx
+++ b/src/js/components/MapPanelZoom.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import Button from 'react-bootstrap/lib/Button';
+import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
+import Icon from './icon.react';
+import { map } from '../map/map';
+import { EventEmitter } from './event-emitter';
+
+export default class MapPanelZoom extends React.Component {
+    /**
+     * Used to setup the state of the component. Regular ES6 classes do not
+     * automatically bind 'this' to the instance, therefore this is the best
+     * place to bind event handlers
+     *
+     * @param props - parameters passed from the parent
+     */
+    constructor (props) {
+        super(props);
+
+        this.state = {
+            zoom: map.getZoom() // Current map zoom position to display
+        };
+
+        this.onClickZoomIn = this.onClickZoomIn.bind(this);
+        this.onClickZoomOut = this.onClickZoomOut.bind(this);
+        this.setZoomLabel = this.setZoomLabel.bind(this);
+    }
+
+    /**
+     * Official React lifecycle method
+     * Invoked once immediately after the initial rendering occurs.
+     * Temporary requirement is to subscribe to events from map becuase it is
+     * not a React component
+     */
+    componentDidMount () {
+        // Need to subscribe to map zooming events so that our React component
+        // plays nice with the non-React map
+        EventEmitter.subscribe('zoomend', data => { this.setZoomLabel(); });
+    }
+
+    /** Zoom functionality **/
+
+    /**
+     * Zoom into the map when user click ZoomIn button
+     */
+    onClickZoomIn () {
+        map.zoomIn(1, { animate: true });
+        this.setZoomLabel();
+    }
+
+    /**
+     * Zoom into the map when user click ZoomOut button
+     */
+    onClickZoomOut () {
+        map.zoomOut(1, { animate: true });
+        this.setZoomLabel();
+    }
+
+    /**
+     * Zoom into the map when user click ZoomOut button
+     */
+    setZoomLabel () {
+        const currentZoom = map.getZoom();
+        const fractionalNumber = Math.floor(currentZoom * 10) / 10;
+        this.setState({ zoom: Number.parseFloat(fractionalNumber).toFixed(1) });
+    }
+
+    render () {
+        return (
+            <div className='map-panel-zoom-container'>
+                <div className='map-panel-zoom'>z{this.state.zoom}</div>
+
+                {/* Zoom buttons */}
+                <ButtonGroup className='buttons-plusminus'>
+                    <OverlayTrigger
+                        rootClose
+                        placement='bottom'
+                        overlay={<Tooltip id='tooltip'>{'Zoom in'}</Tooltip>}
+                    >
+                        <Button onClick={this.onClickZoomIn} className='map-panel-zoomin'>
+                            <Icon type={'bt-plus'} />
+                        </Button>
+                    </OverlayTrigger>
+
+                    <OverlayTrigger
+                        rootClose
+                        placement='bottom'
+                        overlay={<Tooltip id='tooltip'>{'Zoom out'}</Tooltip>}
+                    >
+                        <Button onClick={this.onClickZoomOut}>
+                            <Icon type={'bt-minus'} />
+                        </Button>
+                    </OverlayTrigger>
+                </ButtonGroup>
+            </div>
+        );
+    }
+}

--- a/src/js/components/MapPanelZoomIndicator.jsx
+++ b/src/js/components/MapPanelZoomIndicator.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { EventEmitter } from './event-emitter';
+
+import { map } from '../map/map';
+
+export default class MapPanelZoomIndicator extends React.Component {
+    constructor (props) {
+        super(props);
+
+        this.state = {
+            zoom: this.props.zoom // Current map zoom position to display
+        };
+    }
+
+    componentDidMount () {
+        // Need to subscribe to map zooming events so that our React component
+        // plays nice with the non-React map
+        EventEmitter.subscribe('zoomend', data => {
+            this.setState({ zoom: map.getZoom() });
+        });
+    }
+
+    formatZoom (zoom) {
+        const fractionalNumber = Math.floor(zoom * 10) / 10;
+        return Number.parseFloat(fractionalNumber).toFixed(1);
+    }
+
+    render () {
+        return (
+            <div className='map-panel-zoom'>
+                z{this.formatZoom(this.state.zoom)}
+            </div>
+        );
+    }
+}
+
+MapPanelZoomIndicator.propTypes = {
+    zoom: React.PropTypes.number
+};

--- a/src/js/components/MapPanelZoomIndicator.jsx
+++ b/src/js/components/MapPanelZoomIndicator.jsx
@@ -15,7 +15,7 @@ export default class MapPanelZoomIndicator extends React.Component {
     componentDidMount () {
         // Need to subscribe to map zooming events so that our React component
         // plays nice with the non-React map
-        EventEmitter.subscribe('zoomend', data => {
+        EventEmitter.subscribe('leaflet:zoomend', data => {
             this.setState({ zoom: map.getZoom() });
         });
     }

--- a/src/js/components/map-panel-search-bookmarks.react.js
+++ b/src/js/components/map-panel-search-bookmarks.react.js
@@ -84,7 +84,7 @@ export default class MapPanelSearch extends React.Component {
      */
     componentDidMount () {
         // Need to subscribe to map zooming events so that our React component plays nice with the non-React map
-        EventEmitter.subscribe('moveend', data => {
+        EventEmitter.subscribe('leaflet:moveend', data => {
             let currentLatLng = map.getCenter();
             let delta = getMapChangeDelta(this.state.latlng, currentLatLng);
 

--- a/src/js/components/map-panel-search-bookmarks.react.js
+++ b/src/js/components/map-panel-search-bookmarks.react.js
@@ -85,23 +85,23 @@ export default class MapPanelSearch extends React.Component {
     componentDidMount () {
         // Need to subscribe to map zooming events so that our React component plays nice with the non-React map
         EventEmitter.subscribe('moveend', data => {
-            let currentLatLng = map.getCenter();
-            let delta = getMapChangeDelta(this.state.latlng, currentLatLng);
-
-            // Only update location if the map center has moved more than a given delta
-            // This is actually really necessary because EVERY update in the editor reloads
-            // the map, which fires moveend events despite not actually moving the map
-            // But we also have the bonus of not needing to make a reverse geocode request
-            // for small changes of the map center.
-            if (delta > MAP_UPDATE_DELTA) {
-                this._setCurrentLatLng(currentLatLng);
-                this._reverseGeocode(currentLatLng);
-                this.setState({ bookmarkActive: '' });
-            }
-            if (this.goToActive) {
-                this.setState({ bookmarkActive: 'active-fill' });
-                this.goToActive = false;
-            }
+            // let currentLatLng = map.getCenter();
+            // let delta = getMapChangeDelta(this.state.latlng, currentLatLng);
+            //
+            // // Only update location if the map center has moved more than a given delta
+            // // This is actually really necessary because EVERY update in the editor reloads
+            // // the map, which fires moveend events despite not actually moving the map
+            // // But we also have the bonus of not needing to make a reverse geocode request
+            // // for small changes of the map center.
+            // if (delta > MAP_UPDATE_DELTA) {
+            //     this._setCurrentLatLng(currentLatLng);
+            //     this._reverseGeocode(currentLatLng);
+            //     this.setState({ bookmarkActive: '' });
+            // }
+            // if (this.goToActive) {
+            //     this.setState({ bookmarkActive: 'active-fill' });
+            //     this.goToActive = false;
+            // }
         });
 
         // Need a notification when all bookmarks are cleared succesfully in order to re-render list

--- a/src/js/components/map-panel.react.js
+++ b/src/js/components/map-panel.react.js
@@ -5,12 +5,11 @@ import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import Icon from './icon.react';
+import MapPanelZoom from './MapPanelZoom';
 import MapPanelSearch from './map-panel-search-bookmarks.react';
 
 import { map } from '../map/map';
 import ErrorModal from '../modals/modal.error';
-// Required event dispatch and subscription for now while parts of app are React components and others are not
-import { EventEmitter } from './event-emitter';
 
 /**
  * Represents the main map panel that user can toggle in and out of the leaflet
@@ -28,7 +27,6 @@ export default class MapPanel extends React.Component {
         super(props);
         this.state = {
             open: true, // Whether panel should be open or not
-            zoom: map.getZoom(), // Current map zoom position to display
             geolocatorButton: 'bt-map-arrow', // Icon to display for the geolocator button
             geolocateActive: {
                 active: 'false'
@@ -38,19 +36,6 @@ export default class MapPanel extends React.Component {
         this._toggleMapPanel = this._toggleMapPanel.bind(this);
         this._clickGeolocator = this._clickGeolocator.bind(this);
         this._onGeolocateSuccess = this._onGeolocateSuccess.bind(this);
-        this._clickZoomIn = this._clickZoomIn.bind(this);
-        this._clickZoomOut = this._clickZoomOut.bind(this);
-    }
-
-    /**
-     * Official React lifecycle method
-     * Invoked once immediately after the initial rendering occurs.
-     * Temporary requirement is to subscribe to events from map becuase it is
-     * not a React component
-     */
-    componentDidMount () {
-        // Need to subscribe to map zooming events so that our React component plays nice with the non-React map
-        EventEmitter.subscribe('zoomend', data => { this._setZoomLabel(); });
     }
 
     /**
@@ -58,33 +43,6 @@ export default class MapPanel extends React.Component {
      */
     _toggleMapPanel () {
         this.setState({ open: !this.state.open });
-    }
-
-    /** Zoom functionality **/
-
-    /**
-     * Zoom into the map when user click ZoomOut button
-     */
-    _setZoomLabel () {
-        let currentZoom = map.getZoom();
-        let fractionalNumber = Math.floor(currentZoom * 10) / 10;
-        this.setState({ zoom: fractionalNumber.toFixed(1) });
-    }
-
-    /**
-     * Zoom into the map when user click ZoomIn button
-     */
-    _clickZoomIn () {
-        map.zoomIn(1, { animate: true });
-        this._setZoomLabel();
-    }
-
-    /**
-     * Zoom into the map when user click ZoomOut button
-     */
-    _clickZoomOut () {
-        map.zoomOut(1, { animate: true });
-        this._setZoomLabel();
     }
 
     /** Geolocator functionality **/
@@ -218,8 +176,6 @@ export default class MapPanel extends React.Component {
      * Called every time state or props are changed
      */
     render () {
-        let mapzoom = parseFloat(this.state.zoom).toFixed(1);
-
         return (
             <div>
                 {/* Toggle map panel to show it*/}
@@ -232,17 +188,7 @@ export default class MapPanel extends React.Component {
                 {/* Map panel*/}
                 <Panel collapsible expanded={this.state.open} className='map-panel-collapsible'>
                     <div className='map-panel-toolbar'>
-                        <div className='map-panel-zoom'><span>z{mapzoom}</span></div>
-
-                        {/* Zoom buttons*/}
-                        <ButtonGroup className='buttons-plusminus'>
-                            <OverlayTrigger rootClose placement='bottom' overlay={<Tooltip id='tooltip'>{'Zoom in'}</Tooltip>}>
-                                <Button onClick={this._clickZoomIn} className='map-panel-zoomin'> <Icon type={'bt-plus'} /> </Button>
-                            </OverlayTrigger>
-                            <OverlayTrigger rootClose placement='bottom' overlay={<Tooltip id='tooltip'>{'Zoom out'}</Tooltip>}>
-                                <Button onClick={this._clickZoomOut}> <Icon type={'bt-minus'} /> </Button>
-                            </OverlayTrigger>
-                        </ButtonGroup>
+                        <MapPanelZoom />
 
                         {/* Search buttons*/}
                         <MapPanelSearch geolocateActive={this.state.geolocateActive}/>

--- a/src/js/components/map-panel.react.js
+++ b/src/js/components/map-panel.react.js
@@ -6,7 +6,8 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import Icon from './icon.react';
 import MapPanelZoom from './MapPanelZoom';
-import MapPanelSearch from './map-panel-search-bookmarks.react';
+import MapPanelLocationBar from './MapPanelLocationBar';
+import MapPanelBookmarks from './MapPanelBookmarks';
 
 import { map } from '../map/map';
 import ErrorModal from '../modals/modal.error';
@@ -191,7 +192,10 @@ export default class MapPanel extends React.Component {
                         <MapPanelZoom />
 
                         {/* Search buttons*/}
-                        <MapPanelSearch geolocateActive={this.state.geolocateActive}/>
+                        <div className='map-panel-search-bookmarks'>
+                            <MapPanelLocationBar geolocateActive={this.state.geolocateActive} />
+                            <MapPanelBookmarks />
+                        </div>
 
                         {/* Locate me button*/}
                         <ButtonGroup>

--- a/src/js/map/bookmarks.js
+++ b/src/js/map/bookmarks.js
@@ -28,6 +28,7 @@ function saveBookmark (newBookmark) {
     else {
         currentData.data.push(newBookmark);
         LocalStorage.setItem(STORAGE_BOOKMARKS_KEY, JSON.stringify(currentData));
+        EventEmitter.dispatch('bookmarks:updated');
         return true;
     }
 }

--- a/src/js/map/bookmarks.js
+++ b/src/js/map/bookmarks.js
@@ -49,14 +49,14 @@ function bookmarkExists (newBookmark) {
 // Clear all the bookmarks
 function clearData () {
     LocalStorage.setItem(STORAGE_BOOKMARKS_KEY, JSON.stringify(DEFAULT_BOOKMARKS_OBJECT));
-    EventEmitter.dispatch('clearbookmarks', {});
+    EventEmitter.dispatch('bookmarks:clear', {});
     return true;
 }
 
 // Clear only one bookmark
 function deleteBookmark (index) {
     LocalStorage.deleteItem(STORAGE_BOOKMARKS_KEY, index);
-    EventEmitter.dispatch('clearbookmarks', {});
+    EventEmitter.dispatch('bookmarks:clear', {});
     return true;
 }
 

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -156,10 +156,10 @@ function getMapStartLocation () {
 function setupEventListeners () {
     // Make sure that map zoom label changes when the map is done zooming
     map.on('zoomend', throttle((e) => {
-        EventEmitter.dispatch('zoomend', {});
-    }), 250);
+        EventEmitter.dispatch('leaflet:zoomend', {});
+    }), 500);
     // Any other time the map moves: drag, bookmark select, tangram play edit
     map.on('moveend', throttle((e) => {
-        EventEmitter.dispatch('moveend', {});
+        EventEmitter.dispatch('leaflet:moveend', {});
     }), 1000);
 }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -161,5 +161,5 @@ function setupEventListeners () {
     // Any other time the map moves: drag, bookmark select, tangram play edit
     map.on('moveend', throttle((e) => {
         EventEmitter.dispatch('moveend', {});
-    }), 250);
+    }), 1000);
 }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -6,6 +6,7 @@ import LocalStorage from '../storage/localstorage';
 import { hideSceneLoadingIndicator } from './loading';
 import { handleInspectionHoverEvent, handleInspectionClickEvent } from './inspection';
 import { EventEmitter } from '../components/event-emitter';
+import throttle from 'lodash/throttle';
 
 // We need to manually set the image path when Leaflet is bundled.
 // See https://github.com/Leaflet/Leaflet/issues/766
@@ -149,14 +150,16 @@ function getMapStartLocation () {
 
 /* New section to handle React components */
 
-// Need to setup dispatch services to let the React component MapPanel know when map has changed
+// Need to setup dispatch services to let the React component MapPanel
+// know when map has changed. These are throttled to prevent expensive
+// React operations to be performed in rapid succession.
 function setupEventListeners () {
     // Make sure that map zoom label changes when the map is done zooming
-    map.on('zoomend', function (e) {
+    map.on('zoomend', throttle((e) => {
         EventEmitter.dispatch('zoomend', {});
-    });
+    }), 500);
     // Any other time the map moves: drag, bookmark select, tangram play edit
-    map.on('moveend', function (e) { // drag
+    map.on('moveend', throttle((e) => {
         EventEmitter.dispatch('moveend', {});
-    });
+    }), 500);
 }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -157,9 +157,9 @@ function setupEventListeners () {
     // Make sure that map zoom label changes when the map is done zooming
     map.on('zoomend', throttle((e) => {
         EventEmitter.dispatch('zoomend', {});
-    }), 500);
+    }), 250);
     // Any other time the map moves: drag, bookmark select, tangram play edit
     map.on('moveend', throttle((e) => {
         EventEmitter.dispatch('moveend', {});
-    }), 500);
+    }), 250);
 }


### PR DESCRIPTION
After reviewing issue #469 with @bcamper today, we've determined that the cause of the issue is "death by a thousand cuts" -- when a scene is animated, there's a lot of work the CPU needs to do, and in some cases React is doing enough JavaScript work that it causes zoom-in/zoom-out on the map to lag or be canceled entirely. This PR does a number of relatively simple-to-add performance improvements to the way that some React components respond to changes in the map view. The end result is that scroll-zoom may still feel choppy (particularly in the first few seconds when Tangram Play is first loaded) for highly complex, animated scenes, but is still a dramatic improvement over recent performance.

Here is a summary of those changes.

1. When the map view changes (and fires `zoomend` and `moveend` events) we send events that several React components subscribe to. These events are now throttled to 500ms for the `zoomend` event and 1000ms for the `moveend` event. These can be adjusted easily, but the bulk of the performance overhead is still within the React component lifecycle.
2. When `leaflet:moveend` is triggered, the location bar updates its location (name, lat, lng). This update triggered two calls to React's `setState()` method separately, one after the other. In the Javascript profile analysis, this accounted for the bulk of this component's inefficiency. The component has been refactored so that only one `setState` occurs. This required moving the function for formatting the `lat` and `lng` values to be a step inside React's `render()` method, which is an appropriate place to do this, and setting label precision no longer triggers its own `setState()`.
3. The zoom indicator and zoom buttons are now separate components. This represents a small but slightly meaningful improvement, encapsulating the zoom update functionality and making its existing parent component a little smaller. The goal of this is to make React diff as small of a DOM tree as possible when zoom changes. (This is also the reason why `MapPanelZoomIndicator` contains the event listener for `leaflet:zoomend` instead of the parent `MapPanelZoom` -- the tradeoff for not making this a true stateless component is that only _one_ DOM element is ever built, diffed, and rendered when responding to this event.)

In the future, the search / bookmarks bar might be split into smaller subcomponents, like the zoom indicator, to further reduce the amount of DOM diffing React needs to do.
