### PR TITLE
Split location search bar into 2 components

### DIFF
--- a/src/js/components/MapPanelBookmarks.js
+++ b/src/js/components/MapPanelBookmarks.js
@@ -32,6 +32,7 @@ export default class MapPanelBookmarks extends React.Component {
         };
 
         this.shouldDropdownToggle = this.shouldDropdownToggle.bind(this);
+        this.bookmarksClearedCallback = this.bookmarksClearedCallback.bind(this);
     }
 
     componentDidMount () {
@@ -59,11 +60,11 @@ export default class MapPanelBookmarks extends React.Component {
     /**
      * Fires when a user clicks on a bookmark from bookmark list.
      * Causes map and search panel to re-render to go to the location on the bookmark
-     * @param eventKey - each bookmark in the bookmark list identified by a unique
+     * @param key - each bookmark in the bookmark list identified by a unique
      *      key
      */
-    onClickGoToBookmark (eventKey) {
-        const bookmark = this.state.bookmarks[eventKey];
+    onClickGoToBookmark (key) {
+        const bookmark = this.state.bookmarks[key];
 
         const coordinates = { lat: bookmark.lat, lng: bookmark.lng };
         const zoom = bookmark.zoom;
@@ -78,11 +79,11 @@ export default class MapPanelBookmarks extends React.Component {
 
     /**
      * Delete a single bookmark
-     * @param eventKey - the bookmark index to delete
+     * @param key - the bookmark index to delete
      */
-    onClickDeleteSingleBookmark (eventKey) {
+    onClickDeleteSingleBookmark (key) {
         this.overrideBookmarkClose = true; // We want to keep the dropdown open
-        bookmarks.deleteBookmark(eventKey);
+        bookmarks.deleteBookmark(key);
     }
 
     /**
@@ -157,6 +158,9 @@ export default class MapPanelBookmarks extends React.Component {
                     noCaret
                     pullRight
                     className='map-panel-bookmark-button'
+                    // The prop 'id' is required to make 'Dropdown' accessible
+                    // for users using assistive technologies such as screen readers
+                    id='map-panel-bookmark-button'
                     open={this.shouldDropdownToggle()}
                     onToggle={this.shouldDropdownToggle}
                 >
@@ -182,7 +186,6 @@ export default class MapPanelBookmarks extends React.Component {
                                     <MenuItem key={i}>
                                         <div
                                             className='bookmark-dropdown-info'
-                                            eventKey={i}
                                             onClick={() => this.onClickGoToBookmark(i)}
                                         >
                                             <div className='bookmark-dropdown-icon'>
@@ -198,7 +201,6 @@ export default class MapPanelBookmarks extends React.Component {
                                         </div>
                                         <div
                                             className='bookmark-dropdown-delete'
-                                            eventKey={i}
                                             onClick={() => this.onClickDeleteSingleBookmark(i)}
                                         >
                                             <Icon type={'bt-times'} />

--- a/src/js/components/MapPanelBookmarks.js
+++ b/src/js/components/MapPanelBookmarks.js
@@ -1,0 +1,193 @@
+import React from 'react';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
+import DropdownButton from 'react-bootstrap/lib/DropdownButton';
+import MenuItem from 'react-bootstrap/lib/MenuItem';
+import Icon from './icon.react';
+
+import bookmarks from '../map/bookmarks';
+import { map } from '../map/map';
+import Modal from '../modals/modal';
+// Required event dispatch and subscription for now while parts of app are React components and others are not
+import { EventEmitter } from './event-emitter';
+
+/**
+ * Represents the search bar and bookmarks button on the map panel
+ */
+export default class MapPanelBookmarks extends React.Component {
+    /**
+     * Used to setup the state of the component. Regular ES6 classes do not
+     * automatically bind 'this' to the instance, therefore this is the best
+     * place to bind event handlers
+     *
+     * @param props - parameters passed from the parent
+     */
+    constructor (props) {
+        super(props);
+
+        // Most of the time we don't want to override the bookmark button toggle function
+        this.overrideBookmarkClose = false;
+
+        this.state = {
+            bookmarks: this._updateBookmarks() // Stores all bookmarks
+        };
+
+        this._shouldDropdownToggle = this._shouldDropdownToggle.bind(this);
+    }
+
+    componentDidMount () {
+        // Need a notification when all bookmarks are cleared succesfully in order to re-render list
+        EventEmitter.subscribe('bookmarks:clear', data => { this._bookmarkCallback(); });
+    }
+
+    /**
+     * Official React lifecycle method
+     * Invoked immediately after the component's updates are flushed to the DOM
+     * Using a ref to the DOM element overlay tooltip on top of the dropdown button
+     * to make sure its closed after user clicks on a bookmark
+     */
+    componentDidUpdate (prevProps, prevState) {
+        this.refs.culpritOverlay.hide();
+        this.overrideBookmarkClose = false;
+    }
+
+    /**
+     * Fires when a user clicks on a bookmark from bookmark list.
+     * Causes map and search panel to re-render to go to the location on the bookmark
+     * @param eventKey - each bookmark in the bookmark list identified by a unique
+     *      key
+     */
+    _clickGoToBookmark (eventKey) {
+        let bookmarks = this.state.bookmarks;
+        let bookmark = bookmarks[eventKey];
+
+        const coordinates = { lat: bookmark.lat, lng: bookmark.lng };
+        const zoom = bookmark.zoom;
+
+        if (!coordinates || !zoom) {
+            return;
+        }
+
+        map.setView(coordinates, zoom);
+        EventEmitter.dispatch('bookmarks:active');
+    }
+
+    /**
+     * Delete a single bookmark
+     * @param eventKey - the bookmark index to delete
+     */
+    _clickDeleteSingleBookmark (eventKey) {
+        this.overrideBookmarkClose = true; // We want to keep the dropdown open
+        bookmarks.deleteBookmark(eventKey);
+    }
+
+    /**
+     * Callback called when dropdown button wants to change state from open to closed
+     * @param isOpen - state that dropdown wants to render to. Either true or false
+     */
+    _shouldDropdownToggle (isOpen) {
+        if (this.overrideBookmarkClose) {
+            return true;
+        }
+        else {
+            return isOpen;
+        }
+    }
+
+    /**
+     * Delete all bookmarks
+     */
+    _clickDeleteBookmarks () {
+        const modal = new Modal('Are you sure you want to clear your bookmarks? This cannot be undone.', bookmarks.clearData);
+        modal.show();
+    }
+
+    /**
+     * Callback issued from 'bookmarks' object in order to update the panel UI.
+     * Causes a re-render of the bookmarks list
+     */
+    _bookmarkCallback () {
+        this.setState({ bookmarks: this._updateBookmarks() });
+        this.setState({ bookmarkActive: '' });
+    }
+
+    /**
+     * Fetches current bookmarks from 'bookmarks' object a causes re-render of
+     * bookmarks list.
+     */
+    _updateBookmarks () {
+        let newBookmarks = [];
+        let bookmarkList = bookmarks.readData().data;
+
+        for (let i = 0; i < bookmarkList.length; i++) {
+            const bookmark = bookmarkList[i];
+            let fractionalZoom = Math.floor(bookmark.zoom * 10) / 10;
+
+            newBookmarks.push({
+                id: i,
+                label: bookmark.label,
+                lat: bookmark.lat.toFixed(4),
+                lng: bookmark.lng.toFixed(4),
+                zoom: fractionalZoom.toFixed(1),
+                onClick: this._clickGoToBookmark.bind(this),
+                active: ''
+            });
+        }
+
+        return newBookmarks;
+    }
+
+    /**
+     * Official React lifecycle method
+     * Called every time state or props are changed
+     */
+    render () {
+        return (
+            <OverlayTrigger rootClose ref='culpritOverlay' placement='bottom' overlay={<Tooltip id='tooltip-bookmark'>{'Bookmarks'}</Tooltip>}>
+                <DropdownButton title={<Icon type={'bt-bookmark'} />} bsStyle='default' noCaret pullRight className='map-panel-bookmark-button' id='map-panel-bookmark-button' open={this._shouldDropdownToggle()} onToggle={this._shouldDropdownToggle}>
+                    {/* Defining an immediately-invoked function expression inside JSX to decide whether to render full bookmark list or not */}
+                    {(() => {
+                        let bookmarkDropdownList;
+
+                        // If no bookmarks, then display a no bookmarks message
+                        if (this.state.bookmarks.length === 0) {
+                            bookmarkDropdownList =
+                                <MenuItem key='none' className='bookmark-dropdown-center'>
+                                    <div>No bookmarks yet!</div>
+                                </MenuItem>;
+                        }
+                        // If there are bookmarks
+                        else {
+                            // Create the bookmarks list
+                            let list =
+                                this.state.bookmarks.map((result, i) => {
+                                    return <MenuItem key={i}>
+                                                <div className='bookmark-dropdown-info' eventKey={i} onClick={() => this._clickGoToBookmark(i)} >
+                                                    <div className='bookmark-dropdown-icon'><Icon type={'bt-map-marker'} /></div>
+                                                    <div>{result.label}<br />
+                                                        <span className='bookmark-dropdown-text'>{result.lat}, {result.lng}, z{result.zoom}</span>
+                                                    </div>
+                                                </div>
+                                                <div className='bookmark-dropdown-delete' eventKey={i} onClick={() => this._clickDeleteSingleBookmark(i)}>
+                                                    <Icon type={'bt-times'} />
+                                                </div>
+                                            </MenuItem>;
+                                });
+
+                            // Add a delete button at the end
+                            let deletebutton =
+                                <MenuItem key='delete' onSelect={this._clickDeleteBookmarks} className='bookmark-dropdown-center clear-bookmarks'>
+                                    <div>Clear bookmarks</div>
+                                </MenuItem>;
+
+                            // In React we have to use arrays if we want to concatenate two JSX fragments
+                            bookmarkDropdownList = [list, deletebutton];
+                        }
+
+                        return bookmarkDropdownList;
+                    })()}
+                </DropdownButton>
+            </OverlayTrigger>
+        );
+    }
+}

--- a/src/js/components/MapPanelLocationBar.jsx
+++ b/src/js/components/MapPanelLocationBar.jsx
@@ -180,7 +180,6 @@ export default class MapPanelLocationBar extends React.Component {
     onClickSave () {
         const data = this.getCurrentMapViewData();
         if (bookmarks.saveBookmark(data)) {
-            EventEmitter.dispatch('bookmarks:updated');
             this.setState({
                 bookmarkActive: 'active-fill'
             });

--- a/src/js/components/MapPanelLocationBar.jsx
+++ b/src/js/components/MapPanelLocationBar.jsx
@@ -30,13 +30,13 @@ export default class MapPanelLocationBar extends React.Component {
         super(props);
 
         const mapCenter = map.getCenter();
-
-        this.latlngLabelPrecision = 4;
+        const latlngLabelPrecision = 4;
 
         this.state = {
+            latlngLabelPrecision: latlngLabelPrecision,
             latlng: {
-                lat: mapCenter.lat.toFixed(this.latlngLabelPrecision),
-                lng: mapCenter.lng.toFixed(this.latlngLabelPrecision)
+                lat: mapCenter.lat.toFixed(latlngLabelPrecision),
+                lng: mapCenter.lng.toFixed(latlngLabelPrecision)
             }, // Represents lat lng of current position of the map
             value: '', // Represents text in the search bar
             placeholder: '', // Represents placeholder of the search bar
@@ -155,16 +155,21 @@ export default class MapPanelLocationBar extends React.Component {
         // based on the available screen width
         const mapcontainer = document.getElementById('map-container');
         const width = mapcontainer.offsetWidth;
+        let latlngLabelPrecision;
 
         if (width < 600) {
-            this.latlngLabelPrecision = 2;
+            latlngLabelPrecision = 2;
         }
         else if (width < 800) {
-            this.latlngLabelPrecision = 3;
+            latlngLabelPrecision = 3;
         }
         else {
-            this.latlngLabelPrecision = 4;
+            latlngLabelPrecision = 4;
         }
+
+        this.setState({
+            latlngLabelPrecision: latlngLabelPrecision
+        });
     }
 
     /** Bookmark functionality **/
@@ -343,8 +348,8 @@ export default class MapPanelLocationBar extends React.Component {
         };
 
         const latlng = {
-            lat: parseFloat(this.state.latlng.lat).toFixed(this.latlngLabelPrecision),
-            lng: parseFloat(this.state.latlng.lng).toFixed(this.latlngLabelPrecision)
+            lat: parseFloat(this.state.latlng.lat).toFixed(this.state.latlngLabelPrecision),
+            lng: parseFloat(this.state.latlng.lng).toFixed(this.state.latlngLabelPrecision)
         };
 
         return (

--- a/src/js/components/map-panel.react.js
+++ b/src/js/components/map-panel.react.js
@@ -6,7 +6,8 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import Icon from './icon.react';
 import MapPanelZoom from './MapPanelZoom';
-import MapPanelSearch from './map-panel-search-bookmarks.react';
+import MapPanelLocationBar from './MapPanelLocationBar';
+import MapPanelBookmarks from './MapPanelBookmarks';
 
 import { map } from '../map/map';
 import ErrorModal from '../modals/modal.error';
@@ -191,7 +192,10 @@ export default class MapPanel extends React.Component {
                         <MapPanelZoom />
 
                         {/* Search buttons*/}
-                        <MapPanelSearch geolocateActive={this.state.geolocateActive}/>
+                        <div className='map-panel-search-bookmarks'>
+                            <MapPanelLocationBar geolocateActive={this.state.geolocateActive} />
+                            <MapPanelBookmarks />
+                        </div>
 
                         {/* Locate me button*/}
                         <ButtonGroup>

--- a/src/js/map/bookmarks.js
+++ b/src/js/map/bookmarks.js
@@ -28,6 +28,7 @@ function saveBookmark (newBookmark) {
     else {
         currentData.data.push(newBookmark);
         LocalStorage.setItem(STORAGE_BOOKMARKS_KEY, JSON.stringify(currentData));
+        EventEmitter.dispatch('bookmarks:updated');
         return true;
     }
 }

--- a/src/js/map/bookmarks.js
+++ b/src/js/map/bookmarks.js
@@ -49,14 +49,14 @@ function bookmarkExists (newBookmark) {
 // Clear all the bookmarks
 function clearData () {
     LocalStorage.setItem(STORAGE_BOOKMARKS_KEY, JSON.stringify(DEFAULT_BOOKMARKS_OBJECT));
-    EventEmitter.dispatch('clearbookmarks', {});
+    EventEmitter.dispatch('bookmarks:clear', {});
     return true;
 }
 
 // Clear only one bookmark
 function deleteBookmark (index) {
     LocalStorage.deleteItem(STORAGE_BOOKMARKS_KEY, index);
-    EventEmitter.dispatch('clearbookmarks', {});
+    EventEmitter.dispatch('bookmarks:clear', {});
     return true;
 }
 


### PR DESCRIPTION
This further expands on work done in #475, splitting the location bar into two separate components: the Bookmarks are one component, and the Location Bar still contains the search button, autosuggest input, the lat/lng display, and the save bookmark button. By removing Bookmarks from Location Bar's component lifecycle, it shaves off some time when the location bar needs to update because of changes to the location name or lat/lng. 

Some other tweaks in this PR include:

- Bookmarks and Location Bar now communicate updates via `EventEmitter` instead of in component state, since they no longer share that in common.
- The `clearbookmarks` event is renamed `bookmarks:clear`, similar to how we name other events in this app.
- Some updates for code style (AirBnb React style):
    - Internal methods are no longer prefixed with a leading underscore.
    - String refs are replaced with callback refs.
    - Methods re-organized, some renamed (e.g. `onClickThis` vs `clickThis`)
    - Long component attributes are reformatted.
    - Multi-line JSX syntax are wrapped in `(`parentheses`)`.
- Several instances where several `setState` methods are called consecutively have been consolidated.
- Several instances of `let` have been replaced by `const` when their references do not change.
- `httpGet` is replaced with `window.fetch`. These are no longer debounced. It will be the responsibility of other code to throttle the view updates.

@irealva please review!