### PR TITLE
Fork and modify leaflet-hash. See #477

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "codemirror": "5.14.0",
     "gsap": "1.18.3",
     "leaflet": "1.0.0-rc.2",
-    "leaflet-hash": "0.2.1",
     "lodash": "4.11.1",
     "raven-js": "3.0.4",
     "react": "15.2.1",

--- a/src/js/map/leaflet-hash.js
+++ b/src/js/map/leaflet-hash.js
@@ -4,8 +4,7 @@
  * the constructor accepts an opts object whose only settle option right now
  * is `hashUpdateInterval` - how quickly to update the hash.
  * Also now accounts for zoom precision (so it displays zoom to x digits)
- * and does not set the zoom to the nearest integer on load
- * This necessarily assumes recent browsers and Leaflet v1+
+ * This requires recent browsers and Leaflet v1+
  */
 import L from 'leaflet';
 

--- a/src/js/map/leaflet-hash.js
+++ b/src/js/map/leaflet-hash.js
@@ -1,10 +1,14 @@
 /**
- * A reimplementation of mlevan's leaflet-hash in ES6.
- * Some additions
- * the constructor accepts an opts object whose only settle option right now
- * is `hashUpdateInterval` - how quickly to update the hash.
- * Also now accounts for zoom precision (so it displays zoom to x digits)
- * This requires recent browsers and Leaflet v1+
+ * A port of mlevan's leaflet-hash to ES2015 JavaScript.
+ * Original: https://github.com/mlevans/leaflet-hash
+ *
+ * Changelog:
+ * The constructor now accepts an `opts` object as a second parameter.
+ * The only option right now is `refreshInterval` - how quickly to update the hash.
+ * Also now accounts for fractional zoom precision (so it displays zoom to x digits)
+ * This deprecates support for very old browsers because it no longer checks
+ * for presence of hashchange event
+ * and assumes Leaflet v1+ with fractional zoom quantities
  */
 import L from 'leaflet';
 
@@ -14,7 +18,7 @@ export default class LeafletHash {
         this.lastHash = null;
         this.movingMap = false;
 
-        this.hashUpdateInterval = opts.hashUpdateInterval || 100;
+        this.refreshInterval = opts.refreshInterval || 100;
 
         // defer hash change updates every 100ms
         this.changeDefer = 100;
@@ -135,7 +139,7 @@ export default class LeafletHash {
     }
 
     startListening () {
-        this.map.on('moveend', L.Util.throttle(this.onMapMove, this.hashUpdateInterval, this), this);
+        this.map.on('moveend', L.Util.throttle(this.onMapMove, this.refreshInterval, this), this);
 
         L.DomEvent.addListener(window, 'hashchange', this.onHashChange, this);
 
@@ -143,7 +147,7 @@ export default class LeafletHash {
     }
 
     stopListening () {
-        this.map.off('moveend', L.Util.throttle(this.onMapMove, this.hashUpdateInterval, this), this);
+        this.map.off('moveend', L.Util.throttle(this.onMapMove, this.refreshInterval, this), this);
 
         L.DomEvent.removeListener(window, 'hashchange', this.onHashChange, this);
 

--- a/src/js/map/leaflet-hash.js
+++ b/src/js/map/leaflet-hash.js
@@ -1,0 +1,163 @@
+/**
+ * A reimplementation of mlevan's leaflet-hash in ES6.
+ * Some additions
+ * the constructor accepts an opts object whose only settle option right now
+ * is `hashUpdateInterval` - how quickly to update the hash.
+ * Also now accounts for zoom precision (so it displays zoom to x digits)
+ * and does not set the zoom to the nearest integer on load
+ * This necessarily assumes recent browsers and Leaflet v1+
+ */
+import L from 'leaflet';
+
+export default class LeafletHash {
+    constructor (map, opts = {}) {
+        this.map = null;
+        this.lastHash = null;
+        this.movingMap = false;
+
+        this.hashUpdateInterval = opts.hashUpdateInterval || 100;
+
+        // defer hash change updates every 100ms
+        this.changeDefer = 100;
+        this.changeTimeout = null;
+        this.isListening = false;
+        this.hashChangeInterval = null;
+
+        if (map) {
+            this.init(map);
+        }
+    }
+
+    init (map) {
+        this.map = map;
+
+        // reset the hash
+        this.lastHash = null;
+        this.onHashChange();
+
+        if (!this.isListening) {
+            this.startListening();
+        }
+    }
+
+    parseHash (hash) {
+        if (hash.indexOf('#') === 0) {
+            hash = hash.substr(1);
+        }
+
+        const args = hash.split('/');
+
+        if (args.length === 3) {
+            const zoom = Number.parseFloat(args[0]);
+            const lat = Number.parseFloat(args[1]);
+            const lon = Number.parseFloat(args[2]);
+
+            if (isNaN(zoom) || isNaN(lat) || isNaN(lon)) {
+                return false;
+            }
+            else {
+                return {
+                    center: new L.LatLng(lat, lon),
+                    zoom: zoom
+                };
+            }
+        }
+        else {
+            return false;
+        }
+    }
+
+    formatHash (map) {
+        const center = map.getCenter();
+        const zoom = map.getZoom();
+        const precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
+
+        return '#' + [
+            zoom.toFixed(4),
+            center.lat.toFixed(precision),
+            center.lng.toFixed(precision)
+        ].join('/');
+    }
+
+    removeFrom (map) {
+        if (this.changeTimeout) {
+            clearTimeout(this.changeTimeout);
+        }
+
+        if (this.isListening) {
+            this.stopListening();
+        }
+
+        this.map = null;
+    }
+
+    onMapMove () {
+        // bail if we're moving the map (updating from a hash),
+        // or if the map is not yet loaded
+        if (this.movingMap || !this.map._loaded) {
+            return false;
+        }
+
+        const hash = this.formatHash(this.map);
+        if (this.lastHash !== hash) {
+            location.replace(hash);
+            this.lastHash = hash;
+        }
+    }
+
+    update () {
+        const hash = location.hash;
+        if (hash === this.lastHash) {
+            return;
+        }
+
+        const parsed = this.parseHash(hash);
+        if (parsed) {
+            this.movingMap = true;
+            this.map.setView(parsed.center, parsed.zoom);
+            this.movingMap = false;
+        }
+        else {
+            this.onMapMove(this.map);
+        }
+    }
+
+    onHashChange () {
+        // throttle calls to update() so that they only happen every
+        // `changeDefer` ms
+        if (!this.changeTimeout) {
+            this.changeTimeout = setTimeout(() => {
+                this.update();
+                this.changeTimeout = null;
+            }, this.changeDefer);
+        }
+    }
+
+    startListening () {
+        this.map.on('moveend', L.Util.throttle(this.onMapMove, this.hashUpdateInterval, this), this);
+
+        L.DomEvent.addListener(window, 'hashchange', this.onHashChange);
+
+        this.isListening = true;
+    }
+
+    stopListening () {
+        this.map.off('moveend', L.Util.throttle(this.onMapMove, this.hashUpdateInterval, this), this);
+
+        L.DomEvent.removeListener(window, 'hashchange', this.onHashChange);
+
+        this.isListening = false;
+    }
+}
+
+L.hash = function (map) {
+    return new LeafletHash(map);
+};
+
+L.Map.prototype.addHash = function () {
+    this._hash = L.hash(this);
+};
+
+L.Map.prototype.removeHash = function () {
+    this._hash.removeFrom();
+};

--- a/src/js/map/leaflet-hash.js
+++ b/src/js/map/leaflet-hash.js
@@ -26,6 +26,8 @@ export default class LeafletHash {
         if (map) {
             this.init(map);
         }
+
+        this.onHashChange = this.onHashChange.bind(this);
     }
 
     init (map) {
@@ -126,7 +128,7 @@ export default class LeafletHash {
         // throttle calls to update() so that they only happen every
         // `changeDefer` ms
         if (!this.changeTimeout) {
-            this.changeTimeout = setTimeout(() => {
+            this.changeTimeout = window.setTimeout(() => {
                 this.update();
                 this.changeTimeout = null;
             }, this.changeDefer);
@@ -136,7 +138,7 @@ export default class LeafletHash {
     startListening () {
         this.map.on('moveend', L.Util.throttle(this.onMapMove, this.hashUpdateInterval, this), this);
 
-        L.DomEvent.addListener(window, 'hashchange', this.onHashChange);
+        L.DomEvent.addListener(window, 'hashchange', this.onHashChange, this);
 
         this.isListening = true;
     }
@@ -144,7 +146,7 @@ export default class LeafletHash {
     stopListening () {
         this.map.off('moveend', L.Util.throttle(this.onMapMove, this.hashUpdateInterval, this), this);
 
-        L.DomEvent.removeListener(window, 'hashchange', this.onHashChange);
+        L.DomEvent.removeListener(window, 'hashchange', this.onHashChange, this);
 
         this.isListening = false;
     }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -17,7 +17,7 @@ export const map = L.map('map', {
     attributionControl: false,
     maxZoom: 24,
     keyboardZoomOffset: 0.05,
-    zoomSnap: 0 // Set this to prevent zoom snapping on load.
+    zoomSnap: 0 // Enables fractional zoom.
 });
 
 // Declare these exports now, but Tangram is set up later.
@@ -33,10 +33,8 @@ export function initMap () {
     // Create Leaflet map
     map.setView(mapStartLocation.latlng, mapStartLocation.zoom);
 
+    // Add leaflet-hash (forked version)
     const hash = new LeafletHash(map, { refreshInterval: 250 }); // eslint-disable-line no-unused-vars
-
-    // Now we turn the zoomSnap back on, after the load is complete.
-    map.options.zoomSnap = 1;
 
     // Force Leaflet to update itself.
     // This resolves an issue where the map may sometimes not appear

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -1,5 +1,5 @@
 import L from 'leaflet';
-import 'leaflet-hash';
+import LeafletHash from './leaflet-hash';
 import { saveAs } from '../vendor/FileSaver.min.js';
 import Tangram from 'tangram';
 
@@ -31,7 +31,8 @@ export function initMap () {
 
     // Create Leaflet map
     map.setView(mapStartLocation.latlng, mapStartLocation.zoom);
-    const hash = new L.Hash(map); // eslint-disable-line no-unused-vars
+
+    const hash = new LeafletHash(map, { hashUpdateInterval: 250 }); // eslint-disable-line no-unused-vars
 
     // Force Leaflet to update itself.
     // This resolves an issue where the map may sometimes not appear

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -16,7 +16,8 @@ export const map = L.map('map', {
     zoomControl: false,
     attributionControl: false,
     maxZoom: 24,
-    keyboardZoomOffset: 0.05
+    keyboardZoomOffset: 0.05,
+    zoomSnap: 0 // Set this to prevent zoom snapping on load.
 });
 
 // Declare these exports now, but Tangram is set up later.
@@ -34,6 +35,9 @@ export function initMap () {
 
     const hash = new LeafletHash(map, { hashUpdateInterval: 250 }); // eslint-disable-line no-unused-vars
 
+    // Now we turn the zoomSnap back on, after the load is complete.
+    map.options.zoomSnap = 1;
+
     // Force Leaflet to update itself.
     // This resolves an issue where the map may sometimes not appear
     // or only partially appear when this app is first loaded.
@@ -49,8 +53,6 @@ export function initMap () {
     });
 
     setupEventListeners();
-
-    // initMapToolbar();
 }
 
 /**

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -33,7 +33,7 @@ export function initMap () {
     // Create Leaflet map
     map.setView(mapStartLocation.latlng, mapStartLocation.zoom);
 
-    const hash = new LeafletHash(map, { hashUpdateInterval: 250 }); // eslint-disable-line no-unused-vars
+    const hash = new LeafletHash(map, { refreshInterval: 250 }); // eslint-disable-line no-unused-vars
 
     // Now we turn the zoomSnap back on, after the load is complete.
     map.options.zoomSnap = 1;


### PR DESCRIPTION
This gives us the ability to control a few things that `leaflet-hash` does not:

1. We can throttle the speed at which it updates the URL.
2. Zoom is now rounded to 4 digits of precision.