### PR TITLE
Fixing issue #471

### DIFF
--- a/src/js/components/widgets-link/widget-link-number.react.js
+++ b/src/js/components/widgets-link/widget-link-number.react.js
@@ -127,14 +127,21 @@ export default class WidgetLinkNumber extends React.Component {
 
         const val = Math.round(((this.value - this.min) / this.range) * this.width);
 
-        // point
+        // Zero line
         this.ctx.strokeStyle = this.overPoint ? this.selColor : this.fnColor;
         this.ctx.lineWidth = 1;
         this.ctx.beginPath();
-        this.ctx.moveTo(this.offsetX + val, this.height * 0.5);
-        this.ctx.lineTo(this.offsetX + val, this.height);
+        let middle = this.width / 2;
+        let xPos = (-(val - middle)) + middle;
+        this.ctx.moveTo(xPos, this.height * 0.5);
+        this.ctx.lineTo(xPos, this.height);
         this.ctx.closePath();
         this.ctx.stroke();
+
+        // Zero point / text marker
+        this.ctx.font = '14px Roboto';
+        this.ctx.textAlign = 'center';
+        this.ctx.fillText('0', xPos, this.height / 2.5);
 
         this.overPoint = false;
     }


### PR DESCRIPTION
Where the widget-link for numbers where the 0 mark as not displaying correct values.

Also added a zero mark to make the functionality clear. 

<img width="250" alt="screen shot 2016-07-29 at 10 06 51 pm" src="https://cloud.githubusercontent.com/assets/8978670/17267506/333b83ba-55d9-11e6-8860-2426018fc8ab.png">

<img width="250" alt="screen shot 2016-07-29 at 10 06 45 pm" src="https://cloud.githubusercontent.com/assets/8978670/17267507/36cc69c2-55d9-11e6-8ccb-8242dc98900f.png">
