### PR TITLE
Fix icon classNames sometimes containing "undefined"

### DIFF
--- a/src/js/components/icon.react.js
+++ b/src/js/components/icon.react.js
@@ -10,8 +10,18 @@ export default class Icon extends React.Component {
      * Called every time state or props are changed
      */
     render () {
+        let className = 'btm';
+
+        if (this.props.type) {
+            className += ` ${this.props.type}`;
+        }
+
+        if (this.props.active) {
+            className += ` ${this.props.active}`;
+        }
+
         return (
-            <i className={`btm ${this.props.type} ${this.props.active}`}></i>
+            <i className={className}></i>
         );
     }
 }


### PR DESCRIPTION
When `props.type` or `props.active` is not provided to the `Icon` component an `undefined` is printed as one of the class names instead. This is a small patch to remove this unintended behavior.

<img width="571" alt="screenshot 2016-08-01 15 36 59" src="https://cloud.githubusercontent.com/assets/2553268/17311117/ac08f2b6-57fd-11e6-85b6-c34ae7233fe6.png">
