### PR TITLE
Icons: a small refactor.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,6 +23,7 @@ module.exports = function (config) {
 
         browserify: {
             debug: true,
+            extensions: ['.jsx'],
             transform: [
                 ['babelify', { presets: ['es2015', 'react'] }],
                 'brfs'

--- a/src/css/_icon.css
+++ b/src/css/_icon.css
@@ -1,5 +1,5 @@
 /* Works with Black Tie icons */
 .icon-active {
-    color: yellow;
+    color: yellow !important;
     font-weight: 700;
 }

--- a/src/css/_icon.css
+++ b/src/css/_icon.css
@@ -1,0 +1,5 @@
+/* Works with Black Tie icons */
+.icon-active {
+    color: yellow;
+    font-weight: 700;
+}

--- a/src/css/_map-panel.react.css
+++ b/src/css/_map-panel.react.css
@@ -80,11 +80,6 @@
     color: var(--ui-component-text-color);
 }
 
-.map-panel-toolbar i.btm.active-fill {
-    color: yellow;
-    font-weight: 700;
-}
-
 .map-panel * .btn-group {
     margin-right: 2px;
     margin-left: 2px;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -20,6 +20,7 @@
 @import '_divider';
 @import '_map';
 @import '_overlay';
+@import '_icon';
 
 /* + Menu */
 @import '_filedrop';

--- a/src/js/components/Icon.jsx
+++ b/src/js/components/Icon.jsx
@@ -10,14 +10,10 @@ export default class Icon extends React.Component {
      * Called every time state or props are changed
      */
     render () {
-        let className = 'btm';
-
-        if (this.props.type) {
-            className += ` ${this.props.type}`;
-        }
+        let className = `btm ${this.props.type}`;
 
         if (this.props.active) {
-            className += ` ${this.props.active}`;
+            className += ' icon-active';
         }
 
         return (
@@ -30,6 +26,6 @@ export default class Icon extends React.Component {
  * Prop validation required by React
  */
 Icon.propTypes = {
-    type: React.PropTypes.string,
-    active: React.PropTypes.string
+    type: React.PropTypes.string.isRequired,
+    active: React.PropTypes.bool
 };

--- a/src/js/components/MapPanelBookmarks.js
+++ b/src/js/components/MapPanelBookmarks.js
@@ -3,7 +3,7 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import DropdownButton from 'react-bootstrap/lib/DropdownButton';
 import MenuItem from 'react-bootstrap/lib/MenuItem';
-import Icon from './icon.react';
+import Icon from './Icon';
 
 import bookmarks from '../map/bookmarks';
 import { map } from '../map/map';

--- a/src/js/components/MapPanelLocationBar.jsx
+++ b/src/js/components/MapPanelLocationBar.jsx
@@ -4,7 +4,7 @@ import Button from 'react-bootstrap/lib/Button';
 import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
-import Icon from './icon.react';
+import Icon from './Icon';
 
 import { EventEmitter } from './event-emitter';
 import { map } from '../map/map';
@@ -41,7 +41,7 @@ export default class MapPanelLocationBar extends React.Component {
             value: '', // Represents text in the search bar
             placeholder: '', // Represents placeholder of the search bar
             suggestions: [], // Stores search suggestions from autocomplete
-            bookmarkActive: '', // Represents wether bookmark button should show as active
+            bookmarkActive: false, // Represents wether bookmark button should show as active
         };
 
         // Set the value of the search bar to whatever the map is currently pointing to
@@ -71,7 +71,7 @@ export default class MapPanelLocationBar extends React.Component {
             if (delta > MAP_UPDATE_DELTA) {
                 this.reverseGeocode(currentLatLng);
                 this.setState({
-                    bookmarkActive: '',
+                    bookmarkActive: false,
                     latlng: {
                         lat: currentLatLng.lat,
                         lng: currentLatLng.lng
@@ -82,11 +82,11 @@ export default class MapPanelLocationBar extends React.Component {
 
         // Listeners to respond to Bookmark component state changes.
         EventEmitter.subscribe('bookmarks:active', (data) => {
-            this.setState({ bookmarkActive: 'active-fill' });
+            this.setState({ bookmarkActive: true });
         });
 
         EventEmitter.subscribe('bookmarks:inactive', (data) => {
-            this.setState({ bookmarkActive: '' });
+            this.setState({ bookmarkActive: false });
         });
 
         // Need a notification when divider moves to change the latlng label precision
@@ -181,7 +181,7 @@ export default class MapPanelLocationBar extends React.Component {
         const data = this.getCurrentMapViewData();
         if (bookmarks.saveBookmark(data)) {
             this.setState({
-                bookmarkActive: 'active-fill'
+                bookmarkActive: true
             });
         }
     }
@@ -285,7 +285,7 @@ export default class MapPanelLocationBar extends React.Component {
         const lng = suggestion.geometry.coordinates[0];
         map.setView({ lat: lat, lng: lng });
         this.setState({
-            bookmarkActive: '',
+            bookmarkActive: false,
             latlng: {
                 lat: lat,
                 lng: lng

--- a/src/js/components/MapPanelZoom.jsx
+++ b/src/js/components/MapPanelZoom.jsx
@@ -3,7 +3,7 @@ import Button from 'react-bootstrap/lib/Button';
 import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
-import Icon from './icon.react';
+import Icon from './Icon';
 import MapPanelZoomIndicator from './MapPanelZoomIndicator';
 import { map } from '../map/map';
 

--- a/src/js/components/map-panel.react.js
+++ b/src/js/components/map-panel.react.js
@@ -4,7 +4,7 @@ import Panel from 'react-bootstrap/lib/Panel';
 import ButtonGroup from 'react-bootstrap/lib/ButtonGroup';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
-import Icon from './icon.react';
+import Icon from './Icon';
 import MapPanelZoom from './MapPanelZoom';
 import MapPanelLocationBar from './MapPanelLocationBar';
 import MapPanelBookmarks from './MapPanelBookmarks';

--- a/src/js/components/menu-bar.react.js
+++ b/src/js/components/menu-bar.react.js
@@ -7,7 +7,7 @@ import Nav from 'react-bootstrap/lib/Nav';
 import NavItem from 'react-bootstrap/lib/NavItem';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
-import Icon from './icon.react';
+import Icon from './Icon';
 
 import EditorIO from '../editor/io';
 import { openLocalFile } from '../file/open-local';

--- a/src/js/components/widgets-link/widget-link-number.react.js
+++ b/src/js/components/widgets-link/widget-link-number.react.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import Modal from 'react-bootstrap/lib/Modal';
 import Button from 'react-bootstrap/lib/Button';
 import DraggableModal from '../draggable-modal.react';
-import Icon from '../icon.react';
+import Icon from '../Icon';
 
 import { editor } from '../../editor/editor';
 

--- a/src/js/components/widgets-link/widget-link-vec2.react.js
+++ b/src/js/components/widgets-link/widget-link-vec2.react.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import Modal from 'react-bootstrap/lib/Modal';
 import Button from 'react-bootstrap/lib/Button';
 import DraggableModal from '../draggable-modal.react';
-import Icon from '../icon.react';
+import Icon from '../Icon';
 
 import Vector from './vector';
 import { editor } from '../../editor/editor';

--- a/src/js/components/widgets/widget-color/widget-color.react.js
+++ b/src/js/components/widgets/widget-color/widget-color.react.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import Button from 'react-bootstrap/lib/Button';
 import DraggableModal from '../../draggable-modal.react';
-import Icon from '../../icon.react';
+import Icon from '../../Icon';
 import WidgetColorBox from './widget-color-box.react';
 
 import { setCodeMirrorValue } from '../../../editor/editor';

--- a/src/js/components/widgets/widget-vector/widget-vector.react.js
+++ b/src/js/components/widgets/widget-vector/widget-vector.react.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import Button from 'react-bootstrap/lib/Button';
 import DraggableModal from '../../draggable-modal.react.js';
-import Icon from '../../icon.react';
+import Icon from '../../Icon';
 import { setCodeMirrorValue } from '../../../editor/editor';
 
 import THREE from 'three';

--- a/src/js/file/FileDrop.jsx
+++ b/src/js/file/FileDrop.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Icon from '../components/icon.react';
+import Icon from '../components/Icon';
 import EditorIO from '../editor/io';
 
 export default class FileDrop extends React.Component {

--- a/test/components/Icon.spec.js
+++ b/test/components/Icon.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
 
-import Icon from '../../src/js/components/icon.react';
+import Icon from '../../src/js/components/Icon';
 
 describe('<Icon />', () => {
     it('creates an <i> element', function () {
@@ -13,11 +13,7 @@ describe('<Icon />', () => {
         assert.isTrue(shallow(<Icon type='foo' />).contains(<i className='btm foo' />));
     });
 
-    it('passes through a class for the `active` prop', function () {
-        assert.isTrue(shallow(<Icon active='bar' />).contains(<i className='btm bar' />));
-    });
-
-    it('passes through classes for the `type` and `active` props', function () {
-        assert.isTrue(shallow(<Icon type='foo' active='bar' />).contains(<i className='btm foo bar' />));
+    it('set the active class when `active` is true', function () {
+        assert.isTrue(shallow(<Icon type='foo' active={true} />).contains(<i className='btm foo icon-active' />));
     });
 });


### PR DESCRIPTION
Working on icons earlier, I came across a few additional opportunities to make some improvements.

- Rename `icon.react.js` to `Icon.jsx`
- Make `type` a required prop for Icons - an Icon without a type wouldn't display anything anyway, so this makes sure that if an Icon is used then it's going to be used correctly.
- Make `active` a boolean. This allows us standardize what the "active" class is for active icons, and the implementation does not need to know what the active class is. (It was doing the same thing as `type` anyway -- so if you really want to customize a class name, just alter `type` prop.)
- The active class is now `.icon-active` to use the `.icon-` namespace for this component and to decouple it from the menu bar.
- Rewrite tests to take the above into account. We can remove a test since `type` is now required.
- Add a configuration to the test framework to allow files with the `.jsx` extension.
