### PR TITLE
WidgetDropdown: ensure options is always an array

### DIFF
--- a/src/js/components/widgets/widget-dropdown.react.js
+++ b/src/js/components/widgets/widget-dropdown.react.js
@@ -68,7 +68,7 @@ export default class WidgetDropdown extends React.Component {
         // If the dropdown is of type source then get sources from tangramLayer.scene
         if (this.key === 'source') {
             let obj = getAddressSceneContent(tangramLayer.scene, this.props.source);
-            let keys = (obj) ? Object.keys(obj) : {};
+            let keys = (obj) ? Object.keys(obj) : [];
 
             this.setState({ options: keys });
         }
@@ -120,4 +120,8 @@ WidgetDropdown.propTypes = {
     keyType: React.PropTypes.string,
     options: React.PropTypes.array,
     source: React.PropTypes.string
+};
+
+WidgetDropdown.defaultProps = {
+    options: []
 };


### PR DESCRIPTION
In certain (rare) conditions (possibly a race condition, more common when run locally?) the `state.options` property of WidgetDropdown is not defined. This gives `options` a default value of an empty array, and also fixes a situation when `options` may be set to an empty object instead of an array.
