### PR TITLE
Bugfix: handle errors when loading local files

### DIFF
--- a/src/js/editor/io.js
+++ b/src/js/editor/io.js
@@ -39,12 +39,36 @@ const EditorIO = {
             );
         }
     },
+    /**
+     * Wrap FileReader in a Promise and returns it.
+     */
     loadContentFromFile (content) {
-        const reader = new FileReader();
-        reader.onload = function (event) {
-            TangramPlay.load({ contents: event.target.result });
-        };
-        reader.readAsText(content);
+        return new Promise(function (resolve, reject) {
+            // Rejects the Promise immediately if the `content` argument is not
+            // a Blob object provided by a browser's file input control.
+            if (!content instanceof Blob) {
+                reject('Unable to load your file: it is not a valid file type.');
+            }
+
+            const reader = new FileReader();
+
+            // Resolves when FileReader is completely done loading. The `load`
+            // event can fire before the end of a file is encountered so we
+            // listen for `loadend` instead. The Promise resolves with the value
+            // of the file contents but also loads into the editor.
+            reader.addEventListener('loadend', (event) => {
+                TangramPlay.load({ contents: event.target.result });
+                resolve(event.target.result);
+            });
+
+            // If FileReader encounters an error, the Promise is rejected with
+            // the value of the error property on the FileReader object.
+            reader.addEventListener('error', (event) => {
+                reject(reader.error);
+            });
+
+            reader.readAsText(content);
+        });
     }
 };
 

--- a/src/js/file/open-local.js
+++ b/src/js/file/open-local.js
@@ -6,6 +6,9 @@
  * an invisible file input element in memory, and then triggering a click
  * on it, which activates the browser's open dialog.
  */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ErrorModal from '../modals/ErrorModal';
 import EditorIO from '../editor/io';
 
 const el = constructInvisibleFileInputElement();
@@ -23,7 +26,10 @@ function constructInvisibleFileInputElement () {
     fileSelector.style.display = 'none';
     fileSelector.addEventListener('change', function (event) {
         const files = event.target.files;
-        EditorIO.loadContentFromFile(files[0]);
+        EditorIO.loadContentFromFile(files[0]).catch((error) => {
+            // Show error modal
+            ReactDOM.render(<ErrorModal error={error.message || error} />, document.getElementById('modal-container'));
+        });
     });
     return fileSelector;
 }


### PR DESCRIPTION
Bug report via Sentry: https://app.getsentry.com/share/issue/37383436372e313339313835353132/

```
TypeError: Failed to execute 'readAsText' on 'FileReader': parameter 1 is not of type 'Blob'.
```