### PR TITLE
CSS colors can have spaces

### DIFF
--- a/src/js/components/widgets/widget-color/color.js
+++ b/src/js/components/widgets/widget-color/color.js
@@ -57,6 +57,10 @@ export default class Color {
 
     // Creates a tinycolor color object
     _processTinyColor (color) {
+        if (typeof color === 'string') {
+            color = color.replace(/ /g, '');
+        }
+
         let newColor = tinycolor(color);
 
         if (!newColor.isValid()) {

--- a/src/js/components/widgets/widget-color/color.js
+++ b/src/js/components/widgets/widget-color/color.js
@@ -57,6 +57,16 @@ export default class Color {
 
     // Creates a tinycolor color object
     _processTinyColor (color) {
+        // Tangram.js's color parsing library (css-color-parser-js) allows
+        // spaces in color strings, with the following rationale:
+        //     "Remove all whitespace, not compliant, but should just be
+        //      more accepting."
+        // (https://github.com/deanm/css-color-parser-js/blob/master/csscolorparser.js#L132)
+        //
+        // This means someone can author a working scene file with colors
+        // like "light goldenrod yellow", and Tangram Play's color picker
+        // must also support this now. See discussion:
+        // https://github.com/tangrams/tangram-play/issues/519
         if (typeof color === 'string') {
             color = color.replace(/ /g, '');
         }


### PR DESCRIPTION
Filing this in response to issue [#519](https://github.com/tangrams/tangram-play/issues/519) filed by @meetar. Tangram in the background supports CSS colors with spaces in them, just to be flexible for the user. Tangram Play was not supporting this but now is. 