### PR TITLE
Refactor and improve url state management.

### DIFF
--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -1,7 +1,7 @@
 import { editor } from './editor';
 import { jumpToLine } from './codemirror/tools';
 import { isEmptyString } from '../tools/helpers';
-import { getQueryStringObject, serializeToQueryString } from '../tools/url-state';
+import { replaceHistoryState } from '../tools/url-state';
 
 const HIGHLIGHT_CLASS = 'editor-highlight';
 
@@ -322,14 +322,13 @@ function getAllHighlightedLines () {
  *
  */
 export function updateLinesQueryString () {
-    const locationPrefix = window.location.pathname;
-    const queryObj = getQueryStringObject();
     const allHighlightedLines = getAllHighlightedLines();
-
-    queryObj.lines = allHighlightedLines !== '' ? allHighlightedLines : null;
-
-    const queryString = serializeToQueryString(queryObj);
-    window.history.replaceState({}, null, locationPrefix + queryString + window.location.hash);
+    if (allHighlightedLines !== '') {
+        replaceHistoryState({ lines: allHighlightedLines });
+    }
+    else {
+        replaceHistoryState({ lines: null });
+    }
 }
 
 /**

--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -7,8 +7,18 @@ const HIGHLIGHT_CLASS = 'editor-highlight';
 
 let anchorLine;
 let targetLine;
+let hasInitiated = false;
 
-editor.on('gutterClick', function (cm, line, gutter, event) {
+// Add handlers for these events to the editor.
+export function initHighlight () {
+    if (hasInitiated === false) {
+        editor.on('gutterClick', onEditorGutterClick);
+        editor.on('changes', onEditorChanges);
+        hasInitiated = true;
+    }
+}
+
+function onEditorGutterClick (cm, line, gutter, event) {
     // Do work when the click occurs for the left (or main) mouse button only
     if (event.button !== 0) {
         return;
@@ -65,11 +75,11 @@ editor.on('gutterClick', function (cm, line, gutter, event) {
 
     // Update the query string
     updateLinesQueryString();
-});
+}
 
 // Editor operations, such as cut, paste, delete, or inserts, can mutate
 // highlighted lines. This will make sure the query string remains updated.
-editor.on('changes', function (cm, changes) {
+function onEditorChanges (cm, changes) {
     // Small performance tweak: if there's just one change on one line,
     // don't bother updating the query string, which must check the highlight
     // state on all lines
@@ -78,7 +88,7 @@ editor.on('changes', function (cm, changes) {
     }
 
     updateLinesQueryString();
-});
+}
 
 /**
  * Highlights a given line in the document.

--- a/src/js/editor/highlight.js
+++ b/src/js/editor/highlight.js
@@ -1,6 +1,7 @@
 import { editor } from './editor';
 import { jumpToLine } from './codemirror/tools';
-import { isEmptyString, getQueryStringObject, serializeToQueryString } from '../tools/helpers';
+import { isEmptyString } from '../tools/helpers';
+import { getQueryStringObject, serializeToQueryString } from '../tools/url-state';
 
 const HIGHLIGHT_CLASS = 'editor-highlight';
 

--- a/src/js/modals/SaveGistModal.jsx
+++ b/src/js/modals/SaveGistModal.jsx
@@ -10,7 +10,7 @@ import ErrorModal from './ErrorModal';
 import SaveGistSuccessModal from './SaveGistSuggestModal';
 import { saveToGist } from '../storage/gist';
 import { editor } from '../editor/editor';
-import { getQueryStringObject, serializeToQueryString } from '../tools/helpers';
+import { getQueryStringObject, serializeToQueryString } from '../tools/url-state';
 
 // Default values in UI
 const DEFAULT_GIST_SCENE_NAME = 'Tangram scene';

--- a/src/js/modals/SaveGistModal.jsx
+++ b/src/js/modals/SaveGistModal.jsx
@@ -10,7 +10,7 @@ import ErrorModal from './ErrorModal';
 import SaveGistSuccessModal from './SaveGistSuggestModal';
 import { saveToGist } from '../storage/gist';
 import { editor } from '../editor/editor';
-import { getQueryStringObject, serializeToQueryString } from '../tools/url-state';
+import { replaceHistoryState } from '../tools/url-state';
 
 // Default values in UI
 const DEFAULT_GIST_SCENE_NAME = 'Tangram scene';
@@ -154,13 +154,7 @@ export default class SaveGistModal extends React.Component {
 
         // Update the page URL. The scene parameter should
         // reflect the new scene URL.
-        // TODO: Combine with similar functionality in
-        // tangram-play.js updateContent()
-        const queryObj = getQueryStringObject();
-        queryObj.scene = gist.url;
-        const url = window.location.pathname;
-        const queryString = serializeToQueryString(queryObj);
-        window.history.replaceState({}, null, url + queryString + window.location.hash);
+        replaceHistoryState({ scene: gist.url });
 
         // Show success modal
         // TODO

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -27,7 +27,8 @@ import GlslWidgetsLink from './components/widgets-link/glsl-widgets-link';
 import LocalStorage from './storage/localstorage';
 
 // Import Utils
-import { getQueryStringObject, serializeToQueryString, prependProtocolToUrl } from './tools/helpers';
+import { prependProtocolToUrl } from './tools/helpers';
+import { getQueryStringObject, serializeToQueryString } from './tools/url-state';
 import { isGistURL, getSceneURLFromGistAPI } from './tools/gist-url';
 import { debounce, createObjectURL } from './tools/common';
 import { parseYamlString } from './editor/codemirror/yaml-tangram';

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -289,17 +289,20 @@ class TangramPlay {
     updateContent () {
         const content = getEditorContent();
         const url = createObjectURL(content);
+        const isClean = editor.getDoc().isClean();
 
         // Send scene data to Tangram
         loadScene(url);
 
-        // Update the page URL. For editor changes in particular,
-        // the ?scene=parameter should be erased. This prevents
-        // reloading (or copy-pasting the URL) from directing to
+        // Update the page URL. For editor changes in particular (the editor
+        // state is not clean), the ?scene=parameter should be erased. This
+        // prevents reloading (or copy-pasting the URL) from directing to
         // the wrong scene.
         const queryObj = getQueryStringObject();
         if (queryObj.scene) {
-            delete queryObj.scene;
+            if (!isClean) {
+                delete queryObj.scene;
+            }
             const url = window.location.pathname;
             const queryString = serializeToQueryString(queryObj);
             window.history.replaceState({}, null, url + queryString + window.location.hash);

--- a/src/js/tools/helpers.js
+++ b/src/js/tools/helpers.js
@@ -15,69 +15,6 @@ export function isEmptyString (str) {
 }
 
 /**
- * Gets a deserialized object from the current window's URL.
- * It breaks down the query string, e.g. '?scene=foo.yaml'
- * into this: { scene: "foo.yaml" }
- *
- * @param {string} queryString - defaults to window.location.search
- * @returns {Object} deserialized key-value pairs
- */
-export function getQueryStringObject (queryString = window.location.search) {
-    // Slices off the initial '?' separator on the string,
-    // then splits the string into an array of key-value pairs
-    const arr = queryString.slice(1).split('&');
-
-    // For each key-value pair, deserialize to properties on a new object.
-    const queryObj = arr.reduce(function (object, pair) {
-        const keyValue = pair.split('=');
-        const key = decodeURIComponent(keyValue[0]);
-        const value = decodeURIComponent(keyValue[1]);
-
-        // Do not assign if key is a blank string or
-        // if value is undefined. Do not test for 'falsy'
-        // values, which are valid keys and values.
-        if (key !== '' && typeof value !== 'undefined') {
-            object[key] = value;
-        }
-
-        return object;
-    }, {});
-
-    // The lack of a query string should still return an empty
-    // object. This should not be undefined.
-    return queryObj;
-}
-
-/**
- * Given an object of key-value pairs, serializes that object
- * into a valid query string. It turns { scene: "foo.yaml", bar: "baz" }
- * into '?scene=foo.yaml&bar=baz'
- *
- * @param {Object} obj - set of key-value pairs
- * @returns {string} valid facsimile for window.location.search
- */
-export function serializeToQueryString (obj = {}) {
-    const str = [];
-    for (let p in obj) {
-        // Nulls or undefined are skipped. Do not test for "falsy" values
-        // here. Values like `0` or `false` should be stored in the query.
-        if (obj[p] === null || typeof obj[p] === 'undefined') {
-            continue;
-        }
-
-        if (obj.hasOwnProperty(p)) {
-            str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
-        }
-    }
-
-    // Returns a string prepended with '?' separator if
-    // key value pairs are provided; otherwise, returns
-    // an empty string. This allows URL-assemblage to
-    // "just work" if query string is empty.
-    return (str.length > 0) ? '?' + str.join('&') : '';
-}
-
-/**
  * Prepends a relative-protocol string to the beginning of a url.
  *
  * @param {string} url

--- a/src/js/tools/url-state.js
+++ b/src/js/tools/url-state.js
@@ -1,0 +1,70 @@
+/**
+ * This isn't really a router, since Tangram Play currently does not use any
+ * routes. But it does store some information about the state of the
+ * application in the URL query string. This module handles managing this
+ * URL state and updates the location by using the History API (pushState or
+ * replaceState). Do not modify window.location or window.history on your own!
+ */
+
+/**
+ * Gets a deserialized object from the current window's URL.
+ * It breaks down the query string, e.g. '?scene=foo.yaml'
+ * into this: { scene: "foo.yaml" }
+ *
+ * @param {string} queryString - defaults to window.location.search
+ * @returns {Object} deserialized key-value pairs
+ */
+export function getQueryStringObject (queryString = window.location.search) {
+    // Slices off the initial '?' separator on the string,
+    // then splits the string into an array of key-value pairs
+    const arr = queryString.slice(1).split('&');
+
+    // For each key-value pair, deserialize to properties on a new object.
+    const queryObj = arr.reduce(function (object, pair) {
+        const keyValue = pair.split('=');
+        const key = decodeURIComponent(keyValue[0]);
+        const value = decodeURIComponent(keyValue[1]);
+
+        // Do not assign if key is a blank string or
+        // if value is undefined. Do not test for 'falsy'
+        // values, which are valid keys and values.
+        if (key !== '' && typeof value !== 'undefined') {
+            object[key] = value;
+        }
+
+        return object;
+    }, {});
+
+    // The lack of a query string should still return an empty
+    // object. This should not be undefined.
+    return queryObj;
+}
+
+/**
+ * Given an object of key-value pairs, serializes that object
+ * into a valid query string. It turns { scene: "foo.yaml", bar: "baz" }
+ * into '?scene=foo.yaml&bar=baz'
+ *
+ * @param {Object} obj - set of key-value pairs
+ * @returns {string} valid facsimile for window.location.search
+ */
+export function serializeToQueryString (obj = {}) {
+    const str = [];
+    for (let p in obj) {
+        // Nulls or undefined are skipped. Do not test for "falsy" values
+        // here. Values like `0` or `false` should be stored in the query.
+        if (obj[p] === null || typeof obj[p] === 'undefined') {
+            continue;
+        }
+
+        if (obj.hasOwnProperty(p)) {
+            str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
+        }
+    }
+
+    // Returns a string prepended with '?' separator if
+    // key value pairs are provided; otherwise, returns
+    // an empty string. This allows URL-assemblage to
+    // "just work" if query string is empty.
+    return (str.length > 0) ? '?' + str.join('&') : '';
+}


### PR DESCRIPTION
Resolves a few todos:

- Fixes the bug filed by @meetar in #516, where the scene property in the URL state was improperly being deleted even in a fresh load of a gist
- Refactors all code that touches the url query string (and `window.history`), centralizing it into a single module
- Initializes highlighting much later in the boot process -- later, when we finish porting the full application to React, this is important because we cannot assume the editor is ready (and present) immediately.
