### PR TITLE
Save username to gists metadata

### DIFF
--- a/src/js/components/SignInButton.jsx
+++ b/src/js/components/SignInButton.jsx
@@ -9,7 +9,7 @@ import Icon from './Icon';
 import ErrorModal from '../modals/ErrorModal';
 
 import { EventEmitter } from './event-emitter';
-import { fetchUserLogin } from '../user/login';
+import { requestUserLogin, requestUserLogout } from '../user/login';
 import { openLoginWindow } from '../user/login-window';
 import EditorIO from '../editor/io';
 
@@ -45,10 +45,7 @@ export default class SignInButton extends React.Component {
      */
     onClickSignOut (event) {
         EditorIO.checkSaveStateThen(() => {
-            window.fetch('/api/developer/sign_out', {
-                method: 'POST',
-                credentials: 'same-origin'
-            }).then((response) => {
+            requestUserLogout().then((response) => {
                 if (response.ok) {
                     this.setState({
                         isLoggedIn: false,
@@ -65,7 +62,7 @@ export default class SignInButton extends React.Component {
     }
 
     checkLoggedInState () {
-        fetchUserLogin().then((data) => {
+        requestUserLogin().then((data) => {
             const newState = {
                 serverContacted: true
             };

--- a/src/js/components/SignInButton.jsx
+++ b/src/js/components/SignInButton.jsx
@@ -9,7 +9,7 @@ import Icon from './Icon';
 import ErrorModal from '../modals/ErrorModal';
 
 import { EventEmitter } from './event-emitter';
-import { getUserLogin } from '../user/login';
+import { fetchUserLogin } from '../user/login';
 import { openLoginWindow } from '../user/login-window';
 import EditorIO from '../editor/io';
 
@@ -65,7 +65,7 @@ export default class SignInButton extends React.Component {
     }
 
     checkLoggedInState () {
-        getUserLogin().then((data) => {
+        fetchUserLogin().then((data) => {
             const newState = {
                 serverContacted: true
             };

--- a/src/js/storage/gist.js
+++ b/src/js/storage/gist.js
@@ -3,6 +3,7 @@ import { map } from '../map/map';
 import { getScreenshotData } from '../map/screenshot';
 // import { getLocationLabel } from '../map/search'; // TODO: implement now that move to react has changed this
 import { createThumbnail } from '../tools/thumbnail';
+import { getCachedUserLogin } from '../user/login';
 
 import L from 'leaflet';
 
@@ -29,6 +30,7 @@ export function saveToGist (data, successCallback, errorCallback) {
         return createThumbnail(screenshot.url, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
     }).then(thumbnail => {
         const files = {};
+        const cachedLogin = getCachedUserLogin();
         const metadata = {
             name: sceneName,
             view: {
@@ -42,7 +44,8 @@ export function saveToGist (data, successCallback, errorCallback) {
             versions: {
                 tangram: window.Tangram.version,
                 leaflet: L.version
-            }
+            },
+            user: cachedLogin ? cachedLogin.nickname : null
         };
 
         // This is a single YAML file

--- a/src/js/user/login.js
+++ b/src/js/user/login.js
@@ -14,7 +14,7 @@ If logged in, the response looks like this:
 
 let cachedLoginData;
 
-export function fetchUserLogin () {
+export function requestUserLogin () {
     if (window.location.hostname.endsWith('mapzen.com')) {
         return window.fetch('/api/developer.json', { credentials: 'same-origin' })
             .then((response) => {
@@ -35,4 +35,15 @@ export function fetchUserLogin () {
 
 export function getCachedUserLogin () {
     return cachedLoginData;
+}
+
+/**
+ * Assumes this is only available when already logged in, so no host check
+ * is performed.
+ */
+export function requestUserLogout () {
+    return window.fetch('/api/developer/sign_out', {
+        method: 'POST',
+        credentials: 'same-origin'
+    });
 }

--- a/src/js/user/login.js
+++ b/src/js/user/login.js
@@ -12,11 +12,15 @@ If logged in, the response looks like this:
 {"logged_in":true,"id":7,"email":"name@domain.com","nickname":"name","admin":true}
 */
 
-export function getUserLogin () {
+let cachedLoginData;
+
+export function fetchUserLogin () {
     if (window.location.hostname.endsWith('mapzen.com')) {
         return window.fetch('/api/developer.json', { credentials: 'same-origin' })
             .then((response) => {
-                return response.json();
+                const data = response.json();
+                cachedLoginData = data;
+                return data;
             })
             .catch((error) => {
                 console.log(error);
@@ -27,4 +31,8 @@ export function getUserLogin () {
         // indicating that we did not bother fetching developer.json
         return Promise.resolve({ hosted: false });
     }
+}
+
+export function getCachedUserLogin () {
+    return cachedLoginData;
 }


### PR DESCRIPTION
Usernames are cached - this means we don't need to make a new request just to save each time; also, even if a user signs out, we still associate the gist with the last signed-in user. I imagine this to be a pretty rare occurrence (users are prompted to save before signing out) but it means that if we discover anonymous gists from here on out, we'll have an idea of who it belongs to (assuming they've signed in).

This is meant to be a temporary convenience -- we won't need it once scenes are properly saved with user accounts.