### PR TITLE
Map component.

### DIFF
--- a/src/js/components/App.jsx
+++ b/src/js/components/App.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import Map from './Map';
 import MenuBar from './MenuBar';
-import MapPanel from './MapPanel';
 import Shield from '../ui/Shield';
 import FileDrop from '../file/FileDrop';
 // import ColorPalette from './ColorPalette';
@@ -16,13 +15,6 @@ export default class App extends React.Component {
         // This is called here because right now divider position relies on
         // editor and map being set up already
         initDivider();
-
-        // This is not ported yet. Adding this directly to the React component
-        // causes a timer error to occur in the console.
-        // TODO: Figure this out later. It may have to do with timing of when
-        // the map itself is initiated.
-        let mountNode2 = document.getElementById('map-panel');
-        ReactDOM.render(<MapPanel />, mountNode2);
     }
 
     render () {
@@ -36,12 +28,7 @@ export default class App extends React.Component {
                         </div>
                     </div>
 
-                    <div className='map-container' id='map-container'>
-                        <div className='map-view' id='map' />
-                        <div className='map-loading' id='map-loading' />
-                        <div className='map-panel' id='map-panel' />
-                        <div id='map-inspection-components' />
-                    </div>
+                    <Map />
 
                     <div className='divider' id='divider'>
                         <span className='divider-affordance' />

--- a/src/js/components/Map.jsx
+++ b/src/js/components/Map.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import MapPanel from './MapPanel';
+import MapLoading from '../map/loading';
+import { initMap } from '../map/map';
+import { EventEmitter } from './event-emitter';
+
+export default class Map extends React.Component {
+    componentDidMount () {
+        // We have to run initMap here because this instantiates Leaflet
+        // into a map container, which expects the DOM element for it to
+        // exist already. So we can only call it during this lifecycle method.
+        initMap();
+
+        // The problem is that the other map-based sub-components like MapPanel
+        // cannot assume that the map exists already when they're mounted,
+        // because the children of this component will be mounted before
+        // the parent's componentDidMount() is called. So, like all other
+        // inter-component communication outside of the React framework, we
+        // currently use an EventEmitter to report a ready state, which then
+        // populates the sub-components' state. I'd imagine this situation to
+        // improve when we look into a react-leaflet implementation.
+        EventEmitter.dispatch('map:init');
+    }
+
+    render () {
+        return (
+            <div className='map-container' id='map-container'>
+                <div className='map-view' id='map' />
+                <MapLoading />
+                <MapPanel />
+                <div id='map-inspection-components' />
+            </div>
+        );
+    }
+}

--- a/src/js/components/Map.jsx
+++ b/src/js/components/Map.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MapPanel from './MapPanel';
-import MapLoading from '../map/loading';
+import MapLoading from '../map/MapLoading';
 import { initMap } from '../map/map';
 import { EventEmitter } from './event-emitter';
 

--- a/src/js/components/MapPanel.jsx
+++ b/src/js/components/MapPanel.jsx
@@ -179,7 +179,7 @@ export default class MapPanel extends React.Component {
      */
     render () {
         return (
-            <div>
+            <div className='map-panel'>
                 {/* Toggle map panel to show it*/}
                 <OverlayTrigger rootClose placement='bottom' overlay={<Tooltip id='tooltip'>{'Toogle map toolbar'}</Tooltip>}>
                     <Button onClick={this._toggleMapPanel} className='map-panel-button-show'>

--- a/src/js/components/MapPanelLocationBar.jsx
+++ b/src/js/components/MapPanelLocationBar.jsx
@@ -29,14 +29,13 @@ export default class MapPanelLocationBar extends React.Component {
     constructor (props) {
         super(props);
 
-        const mapCenter = map.getCenter();
         const latlngLabelPrecision = 4;
 
         this.state = {
             latlngLabelPrecision: latlngLabelPrecision,
             latlng: {
-                lat: mapCenter.lat.toFixed(latlngLabelPrecision),
-                lng: mapCenter.lng.toFixed(latlngLabelPrecision)
+                lat: 0,
+                lng: 0
             }, // Represents lat lng of current position of the map
             value: '', // Represents text in the search bar
             placeholder: '', // Represents placeholder of the search bar
@@ -44,8 +43,18 @@ export default class MapPanelLocationBar extends React.Component {
             bookmarkActive: false, // Represents wether bookmark button should show as active
         };
 
-        // Set the value of the search bar to whatever the map is currently pointing to
-        this.reverseGeocode(mapCenter);
+        EventEmitter.subscribe('map:init', () => {
+            const mapCenter = map.getCenter();
+            this.setState({
+                latlng: {
+                    lat: mapCenter.lat,
+                    lng: mapCenter.lng
+                }
+            });
+
+            // Set the value of the search bar to whatever the map is currently pointing to
+            this.reverseGeocode(mapCenter);
+        });
 
         this.relocatingMap = false;
         this.shouldCloseDropdownNextEnter = false; // Boolean to track whether we should close the map on next 'Enter'

--- a/src/js/components/MapPanelZoom.jsx
+++ b/src/js/components/MapPanelZoom.jsx
@@ -31,6 +31,12 @@ export default class MapPanelZoom extends React.Component {
         EventEmitter.subscribe('map:init', () => {
             this.setState({ zoom: map.getZoom() });
         });
+
+        // Need to subscribe to map zooming events so that our React component
+        // plays nice with the non-React map
+        EventEmitter.subscribe('leaflet:zoomend', (data) => {
+            this.setState({ zoom: map.getZoom() });
+        });
     }
 
     /** Zoom functionality **/

--- a/src/js/components/MapPanelZoom.jsx
+++ b/src/js/components/MapPanelZoom.jsx
@@ -6,6 +6,7 @@ import Tooltip from 'react-bootstrap/lib/Tooltip';
 import Icon from './Icon';
 import MapPanelZoomIndicator from './MapPanelZoomIndicator';
 import { map } from '../map/map';
+import { EventEmitter } from './event-emitter';
 
 export default class MapPanelZoom extends React.Component {
     /**
@@ -19,11 +20,17 @@ export default class MapPanelZoom extends React.Component {
         super(props);
 
         this.state = {
-            zoom: map.getZoom() // Current map zoom position to display
+            zoom: 0 // Current map zoom position to display
         };
 
         this.onClickZoomIn = this.onClickZoomIn.bind(this);
         this.onClickZoomOut = this.onClickZoomOut.bind(this);
+    }
+
+    componentDidMount () {
+        EventEmitter.subscribe('map:init', () => {
+            this.setState({ zoom: map.getZoom() });
+        });
     }
 
     /** Zoom functionality **/

--- a/src/js/components/MapPanelZoomIndicator.jsx
+++ b/src/js/components/MapPanelZoomIndicator.jsx
@@ -1,25 +1,6 @@
 import React from 'react';
-import { EventEmitter } from './event-emitter';
 
-import { map } from '../map/map';
-
-export default class MapPanelZoomIndicator extends React.Component {
-    constructor (props) {
-        super(props);
-
-        this.state = {
-            zoom: this.props.zoom // Current map zoom position to display
-        };
-    }
-
-    componentDidMount () {
-        // Need to subscribe to map zooming events so that our React component
-        // plays nice with the non-React map
-        EventEmitter.subscribe('leaflet:zoomend', data => {
-            this.setState({ zoom: map.getZoom() });
-        });
-    }
-
+export default class MapPanelZoomIndicator extends React.PureComponent {
     formatZoom (zoom) {
         const fractionalNumber = Math.floor(zoom * 10) / 10;
         return Number.parseFloat(fractionalNumber).toFixed(1);
@@ -28,7 +9,7 @@ export default class MapPanelZoomIndicator extends React.Component {
     render () {
         return (
             <div className='map-panel-zoom'>
-                z{this.formatZoom(this.state.zoom)}
+                z{this.formatZoom(this.props.zoom)}
             </div>
         );
     }

--- a/src/js/map/MapLoading.jsx
+++ b/src/js/map/MapLoading.jsx
@@ -37,6 +37,8 @@ export default class MapLoading extends React.Component {
 
 /**
  * Shows the scene loading indicator.
+ *
+ * TODO: Deprecate / remove. Map loading should be set via application state.
  */
 export function showSceneLoadingIndicator () {
     EventEmitter.dispatch('maploading:on', {});
@@ -44,6 +46,8 @@ export function showSceneLoadingIndicator () {
 
 /**
  * Hide the scene loading indicator.
+ *
+ * TODO: Deprecate / remove. Map loading should be set via application state.
  */
 export function hideSceneLoadingIndicator () {
     EventEmitter.dispatch('maploading:off', {});

--- a/src/js/map/loading.js
+++ b/src/js/map/loading.js
@@ -1,13 +1,50 @@
+import React from 'react';
+
+// Required event dispatch and subscription for now while
+// parts of app are React components and others are not
+import { EventEmitter } from '../components/event-emitter';
+
+export default class MapLoading extends React.Component {
+    constructor (props) {
+        super(props);
+
+        this.state = {
+            loading: false
+        };
+    }
+
+    componentDidMount () {
+        // When a Modal component fires "on", shield turns itself on.
+        EventEmitter.subscribe('maploading:on', () => {
+            this.setState({ visible: true });
+        });
+
+        // When a Modal component fires "off", shield turns itself off.
+        EventEmitter.subscribe('maploading:off', () => {
+            this.setState({ visible: false });
+        });
+    }
+
+    render () {
+        let classNames = 'map-loading';
+        if (this.state.loading) {
+            classNames += ' map-loading-show';
+        }
+
+        return <div className={classNames} />;
+    }
+}
+
 /**
  * Shows the scene loading indicator.
  */
 export function showSceneLoadingIndicator () {
-    document.getElementById('map-loading').classList.add('map-loading-show');
+    EventEmitter.dispatch('maploading:on', {});
 }
 
 /**
  * Hide the scene loading indicator.
  */
 export function hideSceneLoadingIndicator () {
-    document.getElementById('map-loading').classList.remove('map-loading-show');
+    EventEmitter.dispatch('maploading:off', {});
 }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -3,7 +3,7 @@ import LeafletHash from './leaflet-hash';
 import Tangram from 'tangram';
 
 import LocalStorage from '../storage/localstorage';
-import { hideSceneLoadingIndicator } from './loading';
+import { hideSceneLoadingIndicator } from './MapLoading';
 import { handleInspectionHoverEvent, handleInspectionClickEvent } from './inspection';
 import { EventEmitter } from '../components/event-emitter';
 import throttle from 'lodash/throttle';

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -6,7 +6,7 @@ import { tangramLayer, loadScene } from './map/map';
 import { editor, initEditor, getEditorContent, setEditorContent } from './editor/editor';
 
 // Addons
-import { showSceneLoadingIndicator, hideSceneLoadingIndicator } from './map/loading';
+import { showSceneLoadingIndicator, hideSceneLoadingIndicator } from './map/MapLoading';
 import { initWidgetMarks } from './widgets/widgets-manager';
 import { initErrorsManager } from './editor/errors';
 import { initSuggestions } from './editor/suggest';

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 // Core elements
-import { tangramLayer, initMap, loadScene } from './map/map';
+import { tangramLayer, loadScene } from './map/map';
 import { editor, initEditor, getEditorContent, setEditorContent } from './editor/editor';
 
 // Addons
@@ -29,7 +29,6 @@ const STORAGE_LAST_EDITOR_CONTENT = 'last-content';
 let initialLoad = true;
 
 export function initTangramPlay () {
-    initMap();
     initEditor();
 
     // TODO: Manage history / routing in its own module


### PR DESCRIPTION
This is Reactification Phase 2.1: Map Reactification Phase 1. This is a confusing name - ignore it for now, here are the bullet points:

- The first motivation for this is to make `<MapPanel />` directly mountable as a React Component, rather than have it mounted via `ReactDOM.render()` after `<App />` has mounted. Although not exactly required to do this, I made a `<Map />` component to bundle up any of the stuff in `<div id='map-container'>`.
- This did not immediately solve the problem that happens when you mount `<MapPanel />`, which is that React gives a console error that looks like this: `There is an internal error in the React performance measurement code. Did not expect componentDidMount timer to start while ctor timer is still in progress for another instance.` It's a cryptic message and doesn't give you any clues about what's wrong, so I started solving other problems hoping that it would make this go away. The problem, namely, being that map-based subcomponents cannot simply query the `map` variable (where the Leaflet instance is set to) because when the subcomponents mount, Leaflet has not initiated yet! This is why `<MapPanel />` was previously left to be rendered with `ReactDOM.render()` in `<App />`'s `componentDidMount()` method: It was a brute force way of waiting for Leaflet's container DOM to mount, and for Leaflet to initiate, before any map-based component got rendered.
- So we go back to our good ol' `EventEmitter`, which dispatches `map:init` when Leaflet is ready. The map subcomponents subscribe to that, and update its internal state when that happens. (So no more `map.getZoom()` or `map.getCenter()` during the `constructor()`.) (Does this go away with `react-leaflet`? Presumably. For the moment, this solution works.)

Other additions:
- `<MapLoading>` is the loading bar and is its own component now. It currently shims its exported functions but these should go away in the future.
- `<MapPanelZoomIndicator>` was an impure component because it relied on an event listener to set its own internal state when the map zoom changed. This was done a few weeks ago as a performance tweak, but made the code harder to reason about. It has been converted to a pure component, and receives only its zoom property through its parent, `<MapPanelZoom>`.
- This brought back performance jank in map zooming, but I went back to the profiler for more clues. This led to refactoring `<MapPanelLocationBar>` slightly to remove other unbatched calls to `setState()`. For instance, that component's `reverseGeocode()` now returns a Promise, which enables us to set the entire component's state all at once upon resolution of the Promise. This seems to have brought performance back to an acceptable level.
- **Bonus**: Search API calls are throttled to once per second. See #527 