### PR TITLE
Adding fix for closing the bookmarks dropdown

### DIFF
--- a/src/js/components/MapPanelBookmarks.jsx
+++ b/src/js/components/MapPanelBookmarks.jsx
@@ -29,7 +29,8 @@ export default class MapPanelBookmarks extends React.Component {
         this.overrideBookmarkClose = false;
 
         this.state = {
-            bookmarks: null // We will fill this in during `componentWillMount`
+            bookmarks: null, // We will fill this in during `componentWillMount`,
+            open: false // Controls whether bookmark should be open or closed
         };
 
         this.onClickDeleteBookmarks = this.onClickDeleteBookmarks.bind(this);
@@ -119,10 +120,10 @@ export default class MapPanelBookmarks extends React.Component {
      */
     shouldDropdownToggle (isOpen) {
         if (this.overrideBookmarkClose) {
-            return true;
+            this.setState({ open: true });
         }
         else {
-            return isOpen;
+            this.setState({ open: isOpen });
         }
     }
 
@@ -184,7 +185,7 @@ export default class MapPanelBookmarks extends React.Component {
                     // The prop 'id' is required to make 'Dropdown' accessible
                     // for users using assistive technologies such as screen readers
                     id='map-panel-bookmark-button'
-                    open={this.shouldDropdownToggle()}
+                    open={this.state.open}
                     onToggle={this.shouldDropdownToggle}
                 >
                     {/* Define an immediately-invoked function expression


### PR DESCRIPTION
The bookmarks dropdown was not closing correctly because even though we were keeping track of the toggle state correctly within `shouldDropdownToggle`, the bookmarks button didn't know to re-render because no new state was being set. 

The fix is easy: instead of returning a variable for the `open={}` prop within the dropdown, we set that prop to a `this.state.open`. That way the dropdown knows to re-render anytime there is a state change.