### PR TITLE
Adding ability to not focus by default on embedded version of play

### DIFF
--- a/src/js/editor/codemirror.js
+++ b/src/js/editor/codemirror.js
@@ -51,6 +51,14 @@ const INDENT_UNIT = 4;
  * @returns {CodeMirror} an instance of the CodeMirror editor.
  */
 export function initCodeMirror (el) {
+    let autofocus = true;
+
+    // If we're using an embedded version of play, we don't want the CodeMirror instance to focus by default
+    // since presumably we'll be embedding it within another page
+    if (window.isEmbedded) {
+        autofocus = false;
+    }
+
     const cm = new CodeMirror(el, {
         mode: 'text/x-yaml-tangram',
         theme: 'tangram',
@@ -66,7 +74,7 @@ export function initCodeMirror (el) {
         },
         styleActiveLine: true,
         showCursorWhenSelecting: true,
-        autofocus: true,
+        autofocus: autofocus,
         showTrailingSpace: true,
         matchBrackets: true,
         autoCloseBrackets: true

--- a/src/js/tangram-play.js
+++ b/src/js/tangram-play.js
@@ -57,11 +57,6 @@ export function initTangramPlay () {
                 initErrorsManager();
             }
 
-            if (window.isEmbedded) {
-                // We want to blur the editor so it does not create a cursor in the embedded play
-                editor.getInputField().blur();
-            }
-
             // Things we do after Tangram is finished initializing
             tangramLayer.scene.initializing.then(() => {
                 // Need to send a signal to the dropdown widgets of type source to populate


### PR DESCRIPTION
This is so that when we embed tangram play within an iframe, the iframe does not force a page to scroll to itself. Currently, it is happening in embedded versions of Play because we autofocus on CodeMirror when it initializes. 

Using our `window.isEmbedded` variable we can check whether we're serving an embedded version of play and simply turn autofocus off. 