### PR TITLE
Solve issue #493 with scroll wheel on glsl number pickers

### DIFF
--- a/src/js/components/widgets-link/WidgetLinkNumber.jsx
+++ b/src/js/components/widgets-link/WidgetLinkNumber.jsx
@@ -252,16 +252,12 @@ export default class WidgetLinkNumber extends React.Component {
     onWheel (e) {
         let x = e.deltaY;
 
-        let vel = x - this.prevWheelOffset;
-        let offset = this.offsetX - vel;
+        let offset = this.offsetX - x;
 
         this.setValue(offset / this.center);
-        // this.prevOffset = x;
 
         this.drawCanvas();
         this.setEditorShaderValue(this.value.toFixed(3));
-
-        this.prevWheelOffset = e.deltaY - this.prevWheelOffset;
     }
 
     /**


### PR DESCRIPTION
This solves issue #493 where the numbers changed for a glsl-number picker were a little off when using a scroll wheel. [https://github.com/tangrams/tangram-play/issues/493](https://github.com/tangrams/tangram-play/issues/493)

The solution was to remove an extra offset calculation that was messing up the output value.