### PR TITLE
Fullscreen stuff

### DIFF
--- a/embed/index.html
+++ b/embed/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
     <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
     <title>Tangram Play</title>
-    <script src='../build/js/modernizr.js'></script>
     <link type='text/css' rel='stylesheet' href='../build/css/main.css'>
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
     <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
     <title>Tangram Play</title>
-    <script src='build/js/modernizr.js'></script>
     <link type='text/css' rel='stylesheet' href='build/css/main.css'>
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,6 @@ module.exports = function (config) {
       // 'src/js/**/*.js',
       // // Application
       // 'build/css/main.css',
-      // 'build/js/modernizr.js',
       // 'index.html',
       // Test suites
       'test/**/*.js',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint-js": "eslint src/ test/ --ext .js,.jsx --quiet; eslint *.js --config .eslintrc-legacy --no-eslintrc --quiet",
     "lint-css": "stylelint src/css/*.css",
     "karma": "./node_modules/karma/bin/karma start",
-    "postinstall": "modernizr -c modernizr-config.json -d build/js; gulp build",
+    "postinstall": "gulp build",
     "examples": "npm run examples:scenes && npm run examples:thumbnails",
     "examples:scenes": "node meta/example-scenes/cache-scenes.js",
     "examples:thumbnails": "node meta/example-scenes/cache-thumbnails.js"
@@ -83,7 +83,6 @@
     "karma-sinon": "1.0.5",
     "loose-envify": "1.2.0",
     "mocha": "3.0.2",
-    "modernizr": "3.3.1",
     "phantomjs-prebuilt": "2.1.12",
     "postcss-color-hex-alpha": "2.0.0",
     "postcss-custom-properties": "5.0.1",

--- a/src/js/components/MenuBar.jsx
+++ b/src/js/components/MenuBar.jsx
@@ -13,6 +13,7 @@ import EventEmitter from './event-emitter';
 
 import EditorIO from '../editor/io';
 import { openLocalFile } from '../file/open-local';
+import MenuFullscreen from './MenuFullscreen';
 import ConfirmDialogModal from '../modals/ConfirmDialogModal';
 import ExamplesModal from '../modals/ExamplesModal';
 import AboutModal from '../modals/AboutModal';
@@ -21,7 +22,6 @@ import SaveToCloudModal from '../modals/SaveToCloudModal';
 import OpenFromCloudModal from '../modals/OpenFromCloudModal';
 import OpenGistModal from '../modals/OpenGistModal';
 import OpenUrlModal from '../modals/OpenUrlModal';
-import { toggleFullscreen } from '../ui/fullscreen';
 import { takeScreenshot } from '../map/screenshot';
 import { setGlobalIntrospection } from '../map/inspection';
 import { requestUserSignInState } from '../user/sign-in';
@@ -142,14 +142,12 @@ export default class MenuBar extends React.Component {
         super(props);
         this.state = {
             inspectActive: false, // Represents whether inspect mode is on / off
-            fullscreenActive: false,
             legacyGistMenu: false,
             mapzenAccount: false,
         };
 
         this.getUserData = this.getUserData.bind(this);
         this.clickInspect = this.clickInspect.bind(this);
-        this.clickFullscreen = this.clickFullscreen.bind(this);
     }
 
     // Determine whether some menu items should display
@@ -189,11 +187,6 @@ export default class MenuBar extends React.Component {
         });
     }
 
-    clickFullscreen() {
-        this.setState({ fullscreenActive: !this.state.fullscreenActive });
-        toggleFullscreen();
-    }
-
     clickInspect() {
         const isInspectActive = this.state.inspectActive;
         if (isInspectActive) {
@@ -205,10 +198,6 @@ export default class MenuBar extends React.Component {
         }
     }
 
-    /**
-     * Official React lifecycle method
-     * Called every time state or props are changed
-     */
     render() {
         return (
             <Navbar inverse className="menu-bar">
@@ -330,19 +319,7 @@ export default class MenuBar extends React.Component {
                         </OverlayTrigger>
 
                         {/* Fullscreen button */}
-                        <OverlayTrigger
-                            rootClose
-                            placement="bottom"
-                            overlay={<Tooltip id="tooltip">View fullscreen</Tooltip>}
-                        >
-                            <NavItem
-                                eventKey="new"
-                                onClick={this.clickFullscreen}
-                                active={this.state.fullscreenActive}
-                            >
-                                <Icon type="bt-maximize" />Fullscreen
-                            </NavItem>
-                        </OverlayTrigger>
+                        <MenuFullscreen />
 
                         {/* Help dropdown */}
                         <OverlayTrigger

--- a/src/js/components/MenuFullscreen.jsx
+++ b/src/js/components/MenuFullscreen.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import NavItem from 'react-bootstrap/lib/NavItem';
+import Tooltip from 'react-bootstrap/lib/Tooltip';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Icon from './Icon';
+
+import { getFullscreenElement, toggleFullscreen } from '../ui/fullscreen';
+
+export default class MenuFullscreen extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            fullscreenActive: false,
+        };
+
+        this.checkFullscreenState = this.checkFullscreenState.bind(this);
+    }
+
+    componentDidMount() {
+        // Other actions (like pressing escape) can take users out of fullscreen
+        // mode. When this event is fired, we check to see whether we are in
+        // fullscreen mode and updates the visual state of the menu item.
+        // We listen for all prefixed events because no browser currently
+        // implements Fullscreen API without vendor prefixes.
+        document.addEventListener('fullscreenchange', this.checkFullscreenState, false);
+        document.addEventListener('mozfullscreenchange', this.checkFullscreenState, false);
+        document.addEventListener('webkitfullscreenchange', this.checkFullscreenState, false);
+        document.addEventListener('msfullscreenchange', this.checkFullscreenState, false);
+    }
+
+    onClickFullscreen(event) {
+        toggleFullscreen();
+    }
+
+    checkFullscreenState() {
+        const fullscreenElement = getFullscreenElement();
+        if (fullscreenElement) {
+            this.setState({ fullscreenActive: true });
+        } else {
+            this.setState({ fullscreenActive: false });
+        }
+    }
+
+    render() {
+        return (
+            <OverlayTrigger
+                rootClose
+                placement="bottom"
+                overlay={<Tooltip id="tooltip">View fullscreen</Tooltip>}
+            >
+                <NavItem
+                    eventKey="new"
+                    onClick={this.onClickFullscreen}
+                    active={this.state.fullscreenActive}
+                >
+                    <Icon type="bt-maximize" />Fullscreen
+                </NavItem>
+            </OverlayTrigger>
+        );
+    }
+}

--- a/src/js/components/MenuFullscreen.jsx
+++ b/src/js/components/MenuFullscreen.jsx
@@ -26,7 +26,7 @@ export default class MenuFullscreen extends React.Component {
         document.addEventListener('fullscreenchange', this.checkFullscreenState, false);
         document.addEventListener('mozfullscreenchange', this.checkFullscreenState, false);
         document.addEventListener('webkitfullscreenchange', this.checkFullscreenState, false);
-        document.addEventListener('msfullscreenchange', this.checkFullscreenState, false);
+        document.addEventListener('MSFullscreenChange', this.checkFullscreenState, false);
     }
 
     onClickFullscreen(event) {

--- a/src/js/ui/fullscreen.js
+++ b/src/js/ui/fullscreen.js
@@ -1,24 +1,54 @@
-/* global Modernizr */
 /* eslint-disable import/prefer-default-export */
-// Mozilla (Firefox) has its own language for fullscreen API
-const requestFullscreen = Modernizr.prefixed('requestFullscreen', document.documentElement) ||
-                          Modernizr.prefixed('requestFullScreen', document.documentElement);
-const exitFullscreen = Modernizr.prefixed('exitFullscreen', document) ||
-                       Modernizr.prefixed('cancelFullScreen', document);
+// No browsers as of this writing implement Fullscreen API without prefixes
+// So we look for prefixed versions of each API feature.
+const fullscreenEnabled = document.fullscreenEnabled || // Spec - future
+    document.webkitFullscreenEnabled || // (Blink/Webkit) Chrome/Opera/Edge/Safari
+    document.mozFullScreenEnabled || // (Gecko) Firefox
+    document.msFullscreenEnabled; // IE11
+
+const exitFullscreen = document.exitFullscreen || // Spec
+    document.webkitExitFullscreen || // (Blink/Webkit) Chrome/Opera/Edge/Safari
+    document.mozCancelFullScreen || // (Gecko) Firefox
+    document.msExitFullscreen; // IE11
+
+// Wraps `element.requestFullscreen` in a cross-browser compatible function.
+function requestFullscreen(element) {
+    if (element.requestFullscreen) { // Spec
+        element.requestFullscreen();
+    } else if (element.webkitRequestFullscreen) { // (Blink/Webkit) Chrome/Opera/Edge/Safari
+        element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+    } else if (element.mozRequestFullScreen) { // (Gecko) Firefox
+        element.mozRequestFullScreen();
+    } else if (element.msRequestFullscreen) { // IE11
+        element.msRequestFullscreen();
+    }
+}
+
+/**
+ * Returns the element that is currently being presented in full-screen mode in
+ * this document, or null if full-screen mode is not currently in use. Since
+ * no browser implements this without a prefix, this function accounts for
+ * different cross-browser implementations.
+ *
+ * In Tangram Play the current fullscreen element is assumed to always be
+ * `document.documentElement`, but checking the `fullscreenElement` API returns
+ * null if we are not currently in fullscreen mode, so it is useful to check.
+ */
+function getFullscreenElement() {
+    return document.webkitFullscreenElement ||
+        document.mozFullScreenElement ||
+        document.msFullscreenElement;
+}
 
 export function toggleFullscreen() {
+    // If fullscreen not enabled, ignore
+    if (!fullscreenEnabled) return;
+
     // Is there a current fullscreen element?
-    const fullscreenElement = Modernizr.prefixed('fullscreenElement', document) ||
-                              Modernizr.prefixed('fullScreenElement', document);
+    const fullscreenElement = getFullscreenElement();
 
     if (!fullscreenElement) {
-        // Special case for webkit
-        if (document.documentElement.webkitRequestFullscreen) {
-            requestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
-        } else if (requestFullscreen) {
-            // All other browsers
-            requestFullscreen();
-        }
+        requestFullscreen(document.documentElement);
     } else if (exitFullscreen) {
         exitFullscreen();
     }

--- a/src/js/ui/fullscreen.js
+++ b/src/js/ui/fullscreen.js
@@ -34,7 +34,7 @@ function requestFullscreen(element) {
  * `document.documentElement`, but checking the `fullscreenElement` API returns
  * null if we are not currently in fullscreen mode, so it is useful to check.
  */
-function getFullscreenElement() {
+export function getFullscreenElement() {
     return document.webkitFullscreenElement ||
         document.mozFullScreenElement ||
         document.msFullscreenElement;

--- a/src/js/ui/fullscreen.js
+++ b/src/js/ui/fullscreen.js
@@ -73,4 +73,4 @@ function logFullscreenError(error) {
 document.addEventListener('fullscreenerror', logFullscreenError, false);
 document.addEventListener('mozfullscreenerror', logFullscreenError, false);
 document.addEventListener('webkitfullscreenerror', logFullscreenError, false);
-document.addEventListener('msfullscreenerror', logFullscreenError, false);
+document.addEventListener('MSFullscreenError', logFullscreenError, false);


### PR DESCRIPTION
- Fix a bug where if you exit fullscreen mode by any means other than clicking the fullscreen menu button, its "active" state is toggled in the wrong state
- Refactor out fullscreen menu item into its own component
- Remove Modernizr, which was only used to handle fullscreen API cross-browser compatibility, but required an additional build step