### PR TITLE
Add a color picker for global variables that end in _color.

### DIFF
--- a/src/js/tangram-api.json
+++ b/src/js/tangram-api.json
@@ -300,6 +300,11 @@
       ]
     },
     {
+      "address":"^global:(\\w)+_color$",
+      "type":"color",
+      "defaultValue": "[0.,0.,0.,1.]"
+    },
+    {
       "key": "ambient",
       "type": "color",
       "defaultValue": "[0., 0., 0.]"


### PR DESCRIPTION
This lets you define a color once in `globals:` and reuse it in multiple styles, then change the color with the picker UI. Is there a better way to accomplish this? Globals that end in `_color` seemed like a reasonable convention